### PR TITLE
Allow executable files to be used as externalextractors

### DIFF
--- a/po/ar/kfilemetadata5.po
+++ b/po/ar/kfilemetadata5.po
@@ -1,0 +1,872 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Safa Alfulaij <safa1996alfulaij@gmail.com>, 2015, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2018-08-02 15:48+0300\n"
+"Last-Translator: Safa Alfulaij <safa1996alfulaij@gmail.com>\n"
+"Language-Team: Arabic <doc@arabeyes.org>\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "الترجمات"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "وميض الصورة"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "الألبوم"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "فنان الألبوم"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "الفنان"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "النسبة الباعيّة"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "المؤلف"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "معدل البِتّات"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "القنوات"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "تعليق"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "المدة"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "الملحّن"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "حقوق النشر"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "تاريخ الإنشاء"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "المدة"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "معدل الإطارات"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "برمجية توليد الملف"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "النوع"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "الارتفاع"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "تاريخ الصورة ووقتها"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "طراز الصورة"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "اتجاه الصورة"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "الكلمات المفتاحية"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "اللغة"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "عدد الأسطر"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "كاتب الكلمات"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "عدد الصفحات"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "قيمة فتحة الصورة"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "تاريخ الصورة ووقتها الأصليين"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "تحيّز تعرّض الصورة"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "زمن تعرّض الصورة"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "وميض الصورة"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "رقم الأسطوانة"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "طول الصورة البؤريّ"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "طول الصورة البؤريّ ٣٥مم"
+
+# ترجمة خالد حسني
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "إحداثي دائرة عرض الصورة"
+
+# ترجمة خالد حسني
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "إحداثي خط طول الصورة"
+
+# ترجمة خالد حسني
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "إحداثي الارتفاع الرأسي للصورة"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "تقييم سرعة آيزو للصورة"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "وضع قياس الصورة"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "بُعد الصورة السيني"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "بُعد الصورة الصادي"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "المدة"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "حِدّة الصورة"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "توازن الصورة الأبيض"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "الناشر"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "اللصيقة"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "سنة الإطلاق"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "معدّل الإعتيان"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "الموضوع"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "العنوان"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "رقم المقطوعة"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "رقم الأسطوانة"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "المكان"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "المؤدّي"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "الطاقم"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "المنظّم"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "قائد الفرقة"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "التجميع"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "الرخصة"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "الكلمات"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "أوپوس"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "التقييم"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "العرض"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "عدد الكلمات"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "الوحدات التي يمكن ترجمتها"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "الترجمات"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "الترجمات المسودّة"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "المؤلف"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "آخر تحديث"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "إنشاء القالب"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "نُزّل من"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "موضوع المرفق البريدي"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "مُرسل المرفق البريدي"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "معرّف رسالة المرفق البريدي"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "أرشيف"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "صوت"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "مستند"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "صورة"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "عرض تقديمي"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "جدول ممتد"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "نص"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "فديو"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "مجلد"

--- a/po/az/kfilemetadata5.po
+++ b/po/az/kfilemetadata5.po
@@ -1,0 +1,826 @@
+# Copyright (C) YEAR This file is copyright:
+# This file is distributed under the same license as the kfilemetadata package.
+#
+# Xəyyam <xxmn77@gmail.com>, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2020-04-14 18:32+0400\n"
+"Last-Translator: Xəyyam <xxmn77@gmail.com>\n"
+"Language-Team: Azerbaijani\n"
+"Language: az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 19.12.3\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Dəyişdirilməmiş"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Üfiqi şəkildə əks olundu"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° döndü"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Vertikal əks olundu"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Əsas dioqnala nisbətən əks olundu"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° döndürüldü"
+
+# Şəkil İstiqamətinin izahı
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Köndələn"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° döndürüldü"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Ani parıltı (fləş) yoxdur"
+
+# Foto fləşinin izahı
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "İşlədi"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "İşlədi, işığın əks olunması qeydə alınmadı"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "İşlədi işığın əks olunması qeydə alındı"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Bəli, işləmədi"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Bəli, məcburi"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Bəli, məcburi, işığın əks olunması qeydə alınmadı"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Bəli, məcburi, işığın əks olunması qeydə alındı"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Xeyr, məcbiri"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Xeyr, işləmədi, işığın əks olunması qeydə alınmadı"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Xeyr, avtomatik"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Bəi, avtomatik"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Bəli avtomatik, işığın əks olunması qeydə alınmadı"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Bəli avtomatikişığın əks olunması qeydə alındı"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Fləş funksiyası yoxdur"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Xeyr fləş funksiyası yoxdur"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Bəli, \"qırmızı göz\" olmasın"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Bəli \"qırmızı gğz\" olmasın, əks olunan işıq qeydə alınmadı"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Bəli \"qırmızı göz\" olmasın, əks olunan işıq qeydə alındı"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Bəli, məcburi, \"qırmızı göz\" olmasın"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Bəli, məcburi, \"qırmızı göz\" olmasın, əks olunan işıq qeydə alınmadı"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Bəli, məcburi, \"qırmızı göz\" olmasın, əks olunan işıq qeydə alındı"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Xeyr, \"qırmızı göz\" olmasın"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Xeyr, avtomatik, \"qırmızı göz\" olmasın"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Bəli, avtomatik, \"qırmızı göz\" olmasın"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Bəli, avtomatik, \"qırmızı göz\" olmasın, əks olunan işıq qeydə alınmadı"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+"Bəli, avtomatik,\"qırmızı göz\" olmasın, əks olunan işıq qeydə alınmadı"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Naməlum"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Albom"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albomun İfaçısı"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "İfaçı"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Tərəflərin nisbəti"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Müəllif"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrayt"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanallar"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Şərh"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Xüsusiyyətləri"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Bəstəkar"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Müəllif Hüquqları"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Yaradılma Tarixi"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Müddət"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Kadrların Tezliyi"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Sənədi Yaradan"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Janr"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Hündürlük"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Tarix və Vaxtı"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "İstehsalşı"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Şəklin Səmti"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Açar Sözləri"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Dil"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Sətrlərin Sayı"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Sözlərin Müəllifi"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Səhifələrin Sayı"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Diaframın Dəyəri"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Orijinal Tarix və Vaxt"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Ekspozisiya  meyillliyi"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Ekspozisiya Müddəti"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Ani Parıltı (Fləş)"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Diafraqma Nömrəsi"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Fokus Məsafəsi"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Fokus Məsafəsi 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS En Dairəsi"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS uzunluq dairəsi"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS hündürlüyü"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "İSO Həssaslıq"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Ölçmə Rejimi"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X oxu üzrə öçü"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y oxu üzrə ölçü"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Doyma Çaları"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Kəskinlik"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Bəyazlıq Balansı"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Naşir"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Yarlıq"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Buraxılış İli"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Nümunə Dəyəri"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Mövzu"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Başlıq"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Trek Nömrəsi"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Disk Nömrəsi"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Yerləşmə Yeri"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "İfaçı"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Qrup"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranjemançı"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirijor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Tərtibçi"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Lisenziya"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Sözlıri"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Bəstə"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Reytinq"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Albomun Maksimum Səs Səviyyəsi"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Albomun Səs Səviyyəsi"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Trekin Maksimum Səs Səviyyəsi"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Trekin Səs Səviyyəsi"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "En"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Söz Sayı"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Tərcümə Edilə Bilən Bölmələr"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Tərcümə Olunanlar"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Qaralama Tərcümələr"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Müəllif"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Sonuncu Yeniləmə"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Şablon Yaradılma Tarixi"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Buradan Yükləndi"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-Poçt Əlavələr Movzusu"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-Poçt Əlavələr Göndərən"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-Poçt Əlavələr Masajı İD-si"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arxiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Səs"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Sənəd"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Şəkil"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Təqdimat"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Elekrton Cədvəl"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Mətn"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Qovluq"

--- a/po/bg/kfilemetadata5.po
+++ b/po/bg/kfilemetadata5.po
@@ -1,0 +1,867 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Svetoslav Stefanov <svetlisashkov@yahoo.com>, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2014-05-17 22:19+0200\n"
+"Last-Translator: Svetoslav Stefanov <svetlisashkov@yahoo.com>\n"
+"Language-Team: BULGARIAN <kde-i18n-doc@kde.org>\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 1.5.4\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Снимка - светкавица"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Албум"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Изпълнител на албума"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Изпълнител"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Съотношение"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Автор"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Скорост на предаване"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Канали"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Коментар"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Описание"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Композитор"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Авторско право"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Дата на създаване"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Времетраене"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Кадрова честота"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Жанр"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Височина"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Изображение - дата и час"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Изображение - модел"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Изображение - ориентация"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Ключови думи"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Език"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Брой редове"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Текст на песента"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Брой страници"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Снимка - апертура"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Снимка - оригинални дата и час"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Снимка - компенсация на експозицията"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Снимка - експозиция"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Снимка - светкавица"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Номер на песен"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Снимка - фокусно разстояние"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Снимка - 35mm фокусно разстояние"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Снимка - скорост ISO"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Снимка - режим на измерване"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Снимка - хоризонтален размер"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Снимка - вертикален размер"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Времетраене"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Снимка - острота"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Снимка - баланс на бялото"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Издател"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Година на издаване"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Честота на дискретизация"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Тема"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Заглавие"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Номер на песен"
+
+#: src/propertyinfo.cpp:388
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Номер на песен"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "Времетраене"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Текст на песента"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Широчина"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Брой думи"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Author"
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Автор"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr ""
+
+#: src/propertyinfo.cpp:532
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Orientation"
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Изображение - ориентация"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Архив"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Аудио"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Документ"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Изображение"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Презентация"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Таблица"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Текст"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Видео"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr ""

--- a/po/bs/kfilemetadata5.po
+++ b/po/bs/kfilemetadata5.po
@@ -1,0 +1,868 @@
+# Bosnian translations for PACKAGE package
+# engleski prevodi za paket PACKAGE.
+# Copyright (C) 2014 This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: $2\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2015-02-04 16:00+0000\n"
+"Last-Translator: Samir Ribić <Unknown>\n"
+"Language-Team: none\n"
+"Language: bs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2015-02-05 07:28+0000\n"
+"X-Generator: Launchpad (build 17331)\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Bljesak fotografije"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Dizajner albuma"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Izvođač"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proporcija"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bit brzina"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanali"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Komentar"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "Trajanje"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Kompozitor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Autorska prava"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Datum kreiranja"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Trajanje"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Protok kadrova"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Žanr"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Visina"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Datum i vrijeme slike"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model slike"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Usmjerenje slike"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Ključne riječi"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Jezik"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Broj linija"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Tekstopisac"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Broj strana"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Vrijednost fotografske blende"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Izvorni datum i vrijeme fotografije"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Otklon ekspozicije fotografije"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Vrijeme ekspozicije fotografije"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Bljesak fotografije"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Broj pjesme"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Žarišna dužina fotografije:"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Žižna daljina 35mm fotografije"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Ocjena brzine Photo ISO"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Režim mjerenja fotografije"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X dimenzija fotografije"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y dimenzija fotografije"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Trajanje"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Oštrina fotografije"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balans bijelog fotografije"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Izdavač"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Godina izdanja"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Uzorkovanje"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Tema"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Naslov"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Broj pjesme"
+
+#: src/propertyinfo.cpp:388
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Broj pjesme"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "Trajanje"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Tekstopisac"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Širina"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Broj riječi"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, fuzzy, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr ""
+
+#: src/propertyinfo.cpp:532
+#, fuzzy, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Usmjerenje slike"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arhiva"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Slika"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Prezentacija"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Tablica"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr ""

--- a/po/ca/kfilemetadata5.po
+++ b/po/ca/kfilemetadata5.po
@@ -1,0 +1,829 @@
+# Translation of kfilemetadata5.po to Catalan
+# Copyright (C) 2014-2019 This_file_is_part_of_KDE
+# This file is distributed under the license LGPL version 2.1 or
+# version 3 or later versions approved by the membership of KDE e.V.
+#
+# Josep Ma. Ferrer <txemaq@gmail.com>, 2014, 2015, 2016, 2017, 2018, 2019.
+# Antoni Bella Pérez <antonibella5@yahoo.com>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-22 10:34+0100\n"
+"Last-Translator: Josep Ma. Ferrer <txemaq@gmail.com>\n"
+"Language-Team: Catalan <kde-i18n-ca@kde.org>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Accelerator-Marker: &\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Sense canvis"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Invertida horitzontalment"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Girada 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Invertida verticalment"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposada"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Girada 90° en sentit antihorari"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transversal"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Girada 270° en sentit antihorari"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Sense flaix"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Disparat"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Disparat, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Disparat, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Sí, no s'ha disparat"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Sí, forçat"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Sí, forçat, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Sí, forçat, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "No, forçat"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "No, no s'ha disparat, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, automàtic"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Sí, automàtic"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Sí, automàtic, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Sí, automàtic, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Sense funció de flaix"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "No, sense funció de flaix"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Sí, reducció d'ulls-vermells"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Sí, reducció d'ulls-vermells, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Sí, reducció d'ulls-vermells, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Sí, forçat, reducció d'ulls-vermells"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Sí, forçat, reducció d'ulls-vermells, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Sí, forçat, reducció d'ulls-vermells, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "No, reducció d'ulls-vermells"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "No, automàtic, reducció d'ulls-vermells"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Sí, automàtic, reducció d'ulls-vermells"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Sí, automàtic, reducció d'ulls-vermells, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+"Sí, automàtic, reducció d'ulls-vermells, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Àlbum"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista de l'àlbum"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Relació d'aspecte"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Taxa de bits"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canals"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentari"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descripció"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data de creació"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Durada"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Freqüència dels fotogrames"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Document generat per"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Gènere"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Alçada"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data i hora de la imatge"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientació de la imatge"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Paraules clau"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Comptador de línies"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Lletrista"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Comptador de pàgina"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor d'obertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Data i hora original"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Compensació de l'exposició"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Temps d'exposició"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flaix"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Número F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distància focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distància focal en 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitud del GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitud del GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitud del GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Velocitat ISO de la foto"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mode de mesura"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensió X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensió Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturació"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Nitidesa"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balanç de blancs"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editor"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiqueta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Any d'edició"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Freqüència de mostreig"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Assumpte"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Títol"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Número de la peça"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Número del disc"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Ubicació"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Intèrpret"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Conjunt"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranjaments"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Director"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilació"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Llicència"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Lletres"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Valoració"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Pic d'àlbum de guany de reproducció"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Guany d'àlbum de guany de reproducció"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pic de peça de guany de reproducció"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Guany de peça de guany de reproducció"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Amplada"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Comptador de paraules"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unitats traduïbles"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traduccions"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traduccions inexactes"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Última actualització"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Creació de la plantilla"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Baixat des de"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Assumpte del correu al qual s'ha adjuntat"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Remitent del correu al qual s'ha adjuntat"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID de missatge del correu al qual s'ha adjuntat"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arxiu"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Àudio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Document"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imatge"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentació"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Full de càlcul"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Carpeta"

--- a/po/ca@valencia/kfilemetadata5.po
+++ b/po/ca@valencia/kfilemetadata5.po
@@ -1,0 +1,827 @@
+# Translation of kfilemetadata5.po to Catalan (Valencian)
+# Copyright (C) 2014-2019 This_file_is_part_of_KDE
+# This file is distributed under the license LGPL version 2.1 or
+# version 3 or later versions approved by the membership of KDE e.V.
+#
+# Josep Ma. Ferrer <txemaq@gmail.com>, 2014, 2015, 2016, 2017, 2018, 2019.
+# Antoni Bella Pérez <antonibella5@yahoo.com>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-15 14:18+0100\n"
+"Last-Translator: Josep Ma. Ferrer <txemaq@gmail.com>\n"
+"Language-Team: Catalan <kde-i18n-ca@kde.org>\n"
+"Language: ca@valencia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Accelerator-Marker: &\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Sense canvis"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Invertida horitzontalment"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Girada 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Invertida verticalment"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposada"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Girada 90° en sentit antihorari"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transversal"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Girada 270° en sentit antihorari"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Sense flaix"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Disparat"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Disparat, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Disparat, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Sí, no s'ha disparat"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Sí, forçat"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Sí, forçat, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Sí, forçat, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "No, forçat"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "No, no s'ha disparat, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, automàtic"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Sí, automàtic"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Sí, automàtic, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Sí, automàtic, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Sense funció de flaix"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "No, sense funció de flaix"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Sí, reducció d'ulls-rojos"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Sí, reducció d'ulls-rojos, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Sí, reducció d'ulls-rojos, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Sí, forçat, reducció d'ulls-rojos"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Sí, forçat, reducció d'ulls-rojos, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Sí, forçat, reducció d'ulls-rojos, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "No, reducció d'ulls-rojos"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "No, automàtic, reducció d'ulls-rojos"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Sí, automàtic, reducció d'ulls-rojos"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Sí, automàtic, reducció d'ulls-rojos, no s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Sí, automàtic, reducció d'ulls-rojos, s'ha detectat la llum de retorn"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Àlbum"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista de l'àlbum"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Relació d'aspecte"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Taxa de bits"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canals"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentari"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descripció"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data de creació"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Durada"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Freqüència dels fotogrames"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Document generat per"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Gènere"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Alçària"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data i hora de la imatge"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientació de la imatge"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Paraules clau"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Comptador de línies"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Lletrista"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Comptador de pàgina"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor d'obertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Data i hora original"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Compensació de l'exposició"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Temps d'exposició"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flaix"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Número F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distància focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distància focal en 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitud del GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitud del GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitud del GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Velocitat ISO de la foto"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mode de mesura"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensió X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensió Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturació"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Nitidesa"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balanç de blancs"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editor"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiqueta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Any d'edició"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Freqüència de mostreig"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Assumpte"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Títol"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Número de la peça"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Número del disc"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Ubicació"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Intèrpret"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Conjunt"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranjaments"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Director"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilació"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Llicència"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Lletres"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Valoració"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Pic d'àlbum de guany de reproducció"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Guany d'àlbum de guany de reproducció"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pic de peça de guany de reproducció"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Guany de peça de guany de reproducció"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Amplària"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Comptador de paraules"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unitats traduïbles"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traduccions"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traduccions inexactes"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Última actualització"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Creació de la plantilla"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Baixat des de"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Assumpte del correu al qual s'ha adjuntat"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Remitent del correu al qual s'ha adjuntat"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID de missatge del correu al qual s'ha adjuntat"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arxiu"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Àudio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Document"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imatge"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentació"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Full de càlcul"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Carpeta"

--- a/po/cs/kfilemetadata5.po
+++ b/po/cs/kfilemetadata5.po
@@ -1,0 +1,825 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Vít Pelčák <vit@pelcak.org>, 2014, 2015, 2016, 2017, 2018, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-08-29 16:05+0200\n"
+"Last-Translator: Vit Pelcak <vit@pelcak.org>\n"
+"Language-Team: Czech <kde-i18n-doc@kde.org>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Lokalize 19.08.0\n"
+"X-Language: cs_CZ\n"
+"X-Source-Language: en_US\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Nezměněno"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Převráceno vodorovně"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Otočeno o 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Převráceno svisle"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponováno"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Otočeno o 90° "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Převrácené"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Otočeno o 270°"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Bez blesku"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Ano"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ano, vynucený"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Ne, vynucený"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ne, automaticky"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ano, automaticky"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Bez funkce blesku"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Neznámý"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Umělec alba"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Umělec"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Poměr stran"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Datový tok"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanály"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Komentář"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Popis"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Skladatel"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Datum vytvoření"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Trvání"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Snímkovací frekvence"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokynment byl nevygenerován pomocí"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Žánr"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Výška"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Datum/čas obrázku"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Výrobce"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Natočení obrázku"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Klíčová slova"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Jazyk"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Počet řádků"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Textař"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Počet stran"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Hodnota clony"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Hodnota expozice"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Doba expozice"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blesk"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F číslo"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Ohnisková vzdálenost"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Ohnisková vzdálenost 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Zem. šířka GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Zem. délka GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Výška GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Režim měření"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Rozměr X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Rozměr Y"
+
+# Viz saturation
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Nasycení"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Ostrost"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Vyvážení bílé"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Vydavatel"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Popisek"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Rok vydání"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Vzorkovací frekvence"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Předmět"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Název"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Číslo stopy"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Číslo disku"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Umístění"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Umělec"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranžér"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Sestavování"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licence"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Text písně"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Hodnocení"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Šířka"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Počet slov"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Přeložitelné jednotky"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Překlady"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Poslední aktualizace"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Vytvoření šablony"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Staženo z"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Předmět přílohy e-mailu"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Odesílatel přílohy e-mailu"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID zprávy přílohy e-mailu"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Obrázek"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Prezentace"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Tabulka"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Složka"

--- a/po/da/kfilemetadata5.po
+++ b/po/da/kfilemetadata5.po
@@ -1,0 +1,822 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Martin Schlander <mschlander@opensuse.org>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-08-14 18:39+0100\n"
+"Last-Translator: Martin Schlander <mschlander@opensuse.org>\n"
+"Language-Team: Danish <kde-i18n-doc@kde.org>\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Uændret"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Vendt horisontalt"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Roteret 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Vendt vertikalt"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponeret"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Roteret 90° mod uret"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transverseret"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Roteret 270° mod uret"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Ingen blitz"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Udløst"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Udløst, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Udløst, returlys detekteret"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ja, udløste ikke"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ja, obligatorisk"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ja, obligatorisk, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ja, obligatorisk, returlys detekteret"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nej, obligatorisk"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nej, udløste ikke, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nej, automatisk"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ja, automatisk"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ja, automatisk, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ja, automatisk, returlys detekteret"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Ingen blitzfunktion"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nej, ingen blitzfunktion"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ja, reduktion af røde øjne"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ja, reduktion af røde øjne, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ja, reduktion af røde øjne, returlys detekteret"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ja, obligatorisk, reduktion af røde øjne"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Ja, obligatorisk, reduktion af røde øjne, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Ja, obligatorisk, reduktion af røde øjne, returlys detekteret"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nej, reduktion af røde øjne"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nej, automatisk, reduktion af røde øjne"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Ja, automatisk, reduktion af røde øjne"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Ja, automatisk, reduktion af røde øjne, returlys ikke detekteret"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ja, automatisk, reduktion af røde øjne, returlys detekteret"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albummets kunstner"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Kunstner"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Aspektforhold"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Ophavsmand"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanaler"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Beskrivelse"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Komponist"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Ophavsret"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Oprettelsesdato"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Varighed"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Billedrate"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument genereret af"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Højde"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Billeddato og -tid"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Producent"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Billedorientering"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Nøgleord"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Sprog"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Linjeantal"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Tekstforfatter"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Sideantal"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Blænderværdi"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Oprindelig dato og tid"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Eksponeringsbias"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Eksponeringstid"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blitz"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F-nummer"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Brændvidde"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Brændvidde 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS-breddegrad"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS-længdegrad"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS-højde"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO hastighedsmåling"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Måletilstand"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X-dimension"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y-dimension"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Farvemætning"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Skarphed"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Hvidbalance"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Udgiver"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiket"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Udgivelsesår"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Samplingsrate"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Emne"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Spornummer"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Disknummer"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Placering"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Kunstner"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangør"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Antologi"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licens"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Sangtekst"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Vurdering"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Replay Gain album-peak"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Replay Gain album-peak"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Replay Gain spor-peak"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Replay Gain spor-peak"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Bredde"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Antal ord"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Enheder som kan oversættes"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Oversættelser"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Kladder til oversættelser"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Ophavsmand"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Sidst opdateret"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Oprettelse af skabelon"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Downloadet fra"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Emnet for e-mail-bilag"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Afsender af e-mail-bilag"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Brev-id for e-mail-bilag"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arkiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Lyd"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Billede"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Præsentation"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Regneark"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Mappe"

--- a/po/de/kfilemetadata5.po
+++ b/po/de/kfilemetadata5.po
@@ -1,0 +1,820 @@
+# Burkhard Lück <lueck@hube-lueck.de>, 2014, 2015, 2016, 2017, 2018, 2019, 2021.
+# Frederik Schwarzer <schwarzer@kde.org>, 2016, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2021-04-18 10:59+0200\n"
+"Last-Translator: Burkhard Lück <lueck@hube-lueck.de>\n"
+"Language-Team: German <kde-i18n-de@kde.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 19.12.3\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Unverändert"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Waagerecht gedreht"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° gedreht"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Senkrecht gedreht"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Seitenverkehrt"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° gegen den Uhrzeigersinn gedreht"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Überkreuz gedreht"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° gegen den Uhrzeigersinn gedreht"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Kein Blitz"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Ausgelöst"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Blitz ausgelöst, keine Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Blitz ausgelöst, Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ja, Blitz löste nicht aus"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ja, erzwungen"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ja, erzwungen, Blitzreflektion nicht erkannt"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ja, erzwungen, Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nein, erzwungen"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nein, Blitz ausgelöst, keine Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nein, automatisch"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ja, automatisch"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ja, automatisch, Blitzreflektion nicht erkannt"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ja, automatisch, Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Keine Blitzlichtfunktion"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nein, keine Blitzlichtfunktion"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ja, Rote-Augen-Reduzierung"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ja, Rote-Augen-Reduzierung, Blitzreflektion nicht erkannt"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ja, Rote-Augen-Reduzierung, Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ja, erzwungen, Rote-Augen-Reduzierung"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Ja, erzwungen, Rote-Augen-Reduzierung, Blitzreflektion nicht erkannt"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Ja, erzwungen, Rote-Augen-Reduzierung, Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nein, keine Rote-Augen-Reduzierung"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nein, automatisch, keine Rote-Augen-Reduzierung"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Nein, automatisch, Rote-Augen-Reduzierung"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Ja, automatisch, Rote-Augen-Reduzierung, Blitzreflektion nicht erkannt"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ja, automatisch, Rote-Augen-Reduzierung, Blitzreflektion erkannt"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 LW"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 LW"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 LW"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Interpret des Albums"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Interpret"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Seitenverhältnis"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanäle"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Beschreibung"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Komponist"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Erstellungsdatum"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Dauer"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Bildwiederholrate"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument erstellt von"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Höhe"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Bilddatum und -zeit"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Hersteller"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modell"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Bildausrichtung"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Schlüsselwörter"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Sprache"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Zeilenanzahl"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Texter"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Seitenanzahl"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Blendeneinstellung"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Originaldatum und -zeit"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Belichtungsausgleich"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Belichtungszeit"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blitz"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Blendenwert"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Brennweite"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Brennweite 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS-Breitengrad"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS-Längengrad"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS-Höhe"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO-Empfindlichkeit"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Belichtungsmessung"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X-Dimension"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y-Dimension"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Sättigung"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Schärfentiefe"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Weißabgleich"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Herausgeber"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Beschriftung"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Jahr der Veröffentlichung"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Abtastrate"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Thema"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Nummer des Stücks"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "CD-Nummer"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Ort"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Interpret"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompilierung"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Lizenz"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Liedtext"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Bewertung"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Breite"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Wortanzahl"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Übersetzbare Einheiten"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Übersetzungen"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Fragliche Übersetzungen"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Letzte Aktualisierung"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Vorlagenerstellung"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Heruntergeladen von"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-Mail-Betreff des Anhangs"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-Mail-Absender des Anhangs"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-Mail-Kennung des Anhangs"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Bild"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Präsentation"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Tabellenkalkulation"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Ordner"

--- a/po/el/kfilemetadata5.po
+++ b/po/el/kfilemetadata5.po
@@ -1,0 +1,873 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Antonis Geralis <gaantonio@civil.auth.gr>, 2014.
+# Dimitris Kardarakos <dimkard@gmail.com>, 2014, 2015, 2016.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2016-09-28 13:53+0200\n"
+"Last-Translator: Dimitris Kardarakos <dimkard@gmail.com>\n"
+"Language-Team: Greek <kde-i18n-el@kde.org>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Μεταφράσεις"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Φλας"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Άλμπουμ"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Καλλιτέχνης άλμπουμ"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Καλλιτέχνης"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Αναλογία διαστάσεων"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Συγγραφέας"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Ρυθμός bit"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Κανάλια"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Σχόλιο"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Περιγραφή"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Συνθέτης"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Πνευματικά δικαιώματα"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Ημερομηνία δημιουργίας"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Διάρκεια"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Ρυθμός καρέ"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Είδος"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Ύψος"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Ημερομηνία ώρα"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Μοντέλο"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Προσανατολισμός"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Λέξεις-κλειδιά"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Γλώσσα"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Καταμέτρηση γραμμών"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Στιχουργός"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Αριθμός σελίδων"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Διάφραγμα"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Αρχική ημερομηνία και ώρα"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Τιμή εκτροπής έκθεσης"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Χρόνος έκθεσης"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Φλας"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Αριθμός κομματιού"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Εστιακή απόσταση"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Εστιακή απόσταση 35mm"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Γεωγραφικό πλάτος GPS"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Γεωγραφικό μήκος GPS"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Υψόμετρο GPS"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Ταχύτητα ISO"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Λειτουργία μέτρησης"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Διάσταση X"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Διάσταση Y"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Διάρκεια"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Οξύτητα"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Ισορροπία λευκού"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Εκδότης"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Έτος κυκλοφορίας"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Ρυθμός δειγματοληψίας"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Θέμα"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Τίτλος"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Αριθμός κομματιού"
+
+#: src/propertyinfo.cpp:388
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Αριθμός κομματιού"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "Διάρκεια"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Στιχουργός"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Πλάτος"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Καταμέτρηση λέξεων"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Μεταφράσιμες μονάδες"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Μεταφράσεις"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Προσχέδια μεταφράσεων"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Συγγραφέας"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Τελευταία ενημέρωση"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Δημιουργία προτύπου"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Έγινε λήψη από"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Θέμα ηλ. αλληλογραφίας με συνημμένο"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Αποστολέας ηλ. αλληλογραφίας με συνημμένο"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Αναγνωριστικό ηλ. αλληλογραφίας με συνημμένο"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Αρχειοθήκη"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Ήχος"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Έγγραφο"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Εικόνα"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Παρουσίαση"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Φύλλο εργασίας"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Κείμενο"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Βίντεο"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Φάκελος"

--- a/po/en_GB/kfilemetadata5.po
+++ b/po/en_GB/kfilemetadata5.po
@@ -1,0 +1,822 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Steve Allewell <steve.allewell@gmail.com>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-08-03 15:46+0100\n"
+"Last-Translator: Steve Allewell <steve.allewell@gmail.com>\n"
+"Language-Team: British English <kde-l10n-en_gb@kde.org>\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 19.07.70\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Unchanged"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Horizontally flipped"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° rotated"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Vertically flipped"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposed"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° rotated CCW "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transversed"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° rotated CCW"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "No flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Fired"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Fired, return light not detected"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Fired, return light detected"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Yes, did not fire"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Yes, compulsory"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Yes, compulsory, return light not detected"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Yes, compulsory, return light detected"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "No, compulsory"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "No, did not fire, return light not detected"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, auto"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Yes, auto"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Yes, auto, return light not detected"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Yes, auto, return light detected"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "No flash function"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "No, no flash function"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Yes, red-eye reduction"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Yes, red-eye reduction, return light not detected"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Yes, red-eye reduction, return light detected"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Yes, compulsory, red-eye reduction"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Yes, compulsory, red-eye reduction, return light not detected"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Yes, compulsory, red-eye reduction, return light detected"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "No, red-eye reduction"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "No, auto, red-eye reduction"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Yes, auto, red-eye reduction"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Yes, auto, red-eye reduction, return light not detected"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Yes, auto, red-eye reduction, return light detected"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Unknown"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Album Artist"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artist"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Aspect Ratio"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Author"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Channels"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comment"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Description"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Composer"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Creation Date"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duration"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Frame Rate"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Document Generated By"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Height"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Image Date Time"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Manufacturer"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Image Orientation"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Keywords"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Language"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Line Count"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Lyricist"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Page Count"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Aperture Value"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Original Date Time"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Exposure Bias"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Exposure Time"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F Number"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Focal Length"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Focal Length 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS Latitude"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS Longitude"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS Altitude"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO Speed Rating"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Metering Mode"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X Dimension"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y Dimension"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturation"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Sharpness"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "White Balance"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Publisher"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Label"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Release Year"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Sample Rate"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Subject"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Title"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Track Number"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Disc Number"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Location"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Performer"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranger"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Conductor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilation"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licence"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Lyrics"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Rating"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Replay Gain Album Peak"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Replay Gain Album Gain"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Replay Gain Track Peak"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Replay Gain Track Gain"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Width"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Word Count"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Translatable Units"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Translations"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Draft Translations"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Author"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Last Update"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Template Creation"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Downloaded From"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-Mail Attachment Subject"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-Mail Attachment Sender"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-Mail Attachment Message ID"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archive"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Document"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Image"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentation"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Spreadsheet"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Folder"

--- a/po/es/kfilemetadata5.po
+++ b/po/es/kfilemetadata5.po
@@ -1,0 +1,824 @@
+# Spanish translations for kfilemetadata.po package.
+# Copyright (C) 2014 This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Automatically generated, 2014.
+# Eloy Cuadra <ecuadra@eloihr.net>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-23 19:37+0200\n"
+"Last-Translator: Eloy Cuadra <ecuadra@eloihr.net>\n"
+"Language-Team: Spanish <kde-l10n-es@kde.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 19.04.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Sin cambios"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Volteada horizontalmente"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rotada 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Volteada verticalmente"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Traspuesta"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Rotada 90° en sentido antihorario"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transversada"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Rotada 270° en sentido antihorario"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Sin flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Disparado"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Disparado, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Disparado, luz de retorno detectada"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Sí, no se ha disparado"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Sí, forzado"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Sí, forzado, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Sí, forzado, luz de retorno detectada"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "No, forzado"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "No, no se ha disparado, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, automático"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Sí, automático"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Sí, automático, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Sí, automático, luz de retorno detectada"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Sin función de flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "No, sin función de flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Sí, reducción de ojos rojos"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Sí, reducción de ojos rojos, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Sí, reducción de ojos rojos, luz de retorno detectada"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Sí, forzado, reducción de ojos rojos"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Sí, forzado, reducción de ojos rojos, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Sí, forzado, reducción de ojos rojos, luz de retorno detectada"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "No, reducción de ojos rojos"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "No, automático, reducción de ojos rojos"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Sí, automático, reducción de ojos rojos"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Sí, automático, reducción de ojos rojos, luz de retorno no detectada"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Sí, automático, reducción de ojos rojos, luz de retorno detectada"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Álbum"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista del álbum"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Relación de aspecto"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Tasa de bits"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canales"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentario"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descripción"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Fecha de creación"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duración"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Imágenes por segundo"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Documento generado por"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Género"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altura"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Fecha y hora de la imagen"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modelo"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientación de la imagen"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Palabras clave"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Número de líneas"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Letrista"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Número de páginas"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor de la apertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Fecha y hora originales"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Compensación de exposición"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Tiempo de exposición"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Número F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distancia focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distancia focal en 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitud GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitud GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altura GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Velocidad ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Modo de medición"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensión X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensión Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturación"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Nitidez"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balance de blancos"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editor"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiqueta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Año de publicación"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Frecuencia de muestreo"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Asunto"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Título"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Número de la pista"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Número de disco"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Ubicación"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Intérprete"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Grupo"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arreglista"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Director"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Recopilación"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licencia"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Letra"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Puntuación"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Replay Gain Album Peak"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Replay Gain Album Gain"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Replay Gain Track Peak"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Replay Gain Track Gain"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Anchura"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Número de palabras"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unidades traducibles"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traducciones"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traducciones en borrador"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Última actualización"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Orientación de la plantilla"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Descargado de"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Asunto del correo electrónico del adjunto"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Emisor del correo electrónico del adjunto"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID de mensaje del correo electrónico del adjunto"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archivo"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Documento"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imagen"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentación"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Hoja de cálculo"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Texto"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Carpeta"

--- a/po/et/kfilemetadata5.po
+++ b/po/et/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Marek Laane <qiilaq69@gmail.com>, 2016, 2019, 2020.
+# Mihkel Tõnnov <mihhkel@gmail.com>, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2020-10-07 11:17+0200\n"
+"Last-Translator: Mihkel Tõnnov <mihhkel@gmail.com>\n"
+"Language-Team: Estonian <>\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 20.08.1\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Muutmata"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Rõhtsalt keeratud"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° pööratud"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Püstiselt keeratud"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponeeritud"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° vastupäeva pööratud"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Põiki"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° vastupäeva pööratud"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Välguta"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Välguga"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Välguga, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Välguga, tuvastati peegeldus"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Jah, välku ei kasutatud"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Jah, kohustuslik"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Jah, kohustuslik, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Jah, kohustuslik, tuvastati peegeldus"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Ei, kohustuslik"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Ei, välguta, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ei, automaatne"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Jah, automaatne"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Jah, automaatne, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Jah, automaatne, tuvastati peegeldus"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Välgufunktsioon puudub"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Ei, välgufunktsioon puudub"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Jah, punasilmsuse vähendamine"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Jah, punasilmsuse vähendamine, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Jah, punasilmsuse vähendamine, tuvastati peegeldus"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Jah, kohustuslik, punasilmsuse vähendamine"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Jah, kohustuslik, punasilmsuse vähendamine, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Jah, kohustuslik, punasilmsuse vähendamine, tuvastati peegeldus"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Ei. punasilmsuse vähendamine"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Ei, automaatne, punasilmsuse vähendamine"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Jah, automaatne, punasilmsuse vähendamine"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Jah, automaatne, punasilmsuse vähendamine, peegeldust ei tuvastatud"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Jah, automaatne, punasilmsuse vähendamine, tuvastati peegeldus"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Teadmata"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumi esitaja"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Esitaja"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proportsioon"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitikiirus"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanalid"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentaar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Kirjeldus"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Helilooja"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Autoriõigus"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Loomise kuupäev"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Kestus"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Kaadrisagedus"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokumendi valmistas"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Žanr"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Kõrgus"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Pildi kuupäev ja kellaaeg"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Tootja"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Mudel"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Pildi orientatsioon"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Võtmesõnad"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Keel"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Ridade arv"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Sõnade autor"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Lehekülgede arv"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Ava väärtus"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Originaali kuupäev ja kellaaeg"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Särinihe"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Säriaeg"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Välklamp"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F-arv"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Fookuskaugus"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Fookuskaugus (35 mm)"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS-laiuskraad"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS-pikkuskraad"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS-kõrgus"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO kiirus"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mõõterežiim"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X-mõõde"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y-mõõde"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Küllastus"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Teravus"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Värvustasakaal"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Kirjastaja"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Plaadifirma"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Väljalaskeaasta"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Diskreetimissagedus"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Teema"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Pealkiri"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Raja number"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Plaadi number"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Asukoht"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Esitaja"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ansambel"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranžeeerija"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kogumik"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Litsents"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Sõnad"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Teos"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Hinnang"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Albumi helitugevuse parandamise tipp"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Albumi helitugevuse parandamine"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pala helitugevuse parandamise tipp"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Pala helitugevuse parandamine"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Laius"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Sõnade arv"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Tõlkeühikud"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Tõlked"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Mustandtõlked"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Viimati uuendatud"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Malli loomise aeg"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Allalaadimise asukoht"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-kirja manuse teema"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-kirja manuse saatja"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-kirja manuse kirja ID"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arhiiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Heli"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Pilt"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Esitlus"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Arvutustabel"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Kataloog"

--- a/po/eu/kfilemetadata5.po
+++ b/po/eu/kfilemetadata5.po
@@ -1,0 +1,832 @@
+# Translation of kfilemetadata5.po to Euskara/Basque (eu).
+# Copyright (C) 2017-2018, Free Software Foundation.
+# Copyright (C) 2019, this file is copyright:
+# This file is distributed under the same license as the kfilemetadata package.
+# KDE Euskaratzeko proiektuaren arduraduna <xalba@euskalnet.net>.
+#
+# Translators:
+# Osoitz <oelkoro@gmail.com>, 2017.
+# Iñigo Salvador Azurmendi <xalba@euskalnet.net>, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-23 21:50+0200\n"
+"Last-Translator: Iñigo Salvador Azurmendi <xalba@euskalnet.net>\n"
+"Language-Team: Basque <kde-i18n-eu@kde.org>\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 19.04.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Aldatu gabe"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Horizontalki iraulia"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° biratua"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Bertikalki iraulia"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposatua"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° erloju-orratzen aurkako noranzkoan "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Zeharkatua"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° erloju-orratzen aurkako noranzkoan"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Flashik ez"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Kliskatua"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Kliskatua, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Kliskatua, itzulerako argia hauteman da"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Bai, ez du kliskatu"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Bai, derrigorrezkoa"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Bai, derrigorrezkoa, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Bai, derrigorrezkoa, itzulerako argia hauteman da"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Ez, derrigorrezkoa"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Ez, ez du kliskatu, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ez, auto"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Bai, auto"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Bai, automatikoa, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Bai, automatikoa, itzulerako argia hauteman da"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Flash funtziorik ez"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Ez, flash funtziorik ez"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Bai, begien gorria murriztea"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Bai, begien gorria murriztea, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Bai, begien gorria murriztea, itzulerako argia hauteman da"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Bai, derrigorrezkoa, begien gorria murriztea"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Bai, derrigorrezkoa, begien gorria murriztea, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+"Bai, derrigorrezkoa, begien gorria murriztea, itzulerako argia hauteman da"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Ez, begien gorria murriztea"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Ez, automatikoa, begien gorria murriztea"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Bai, automatikoa, begien gorria murriztea"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Bai, automatikoa, begien gorria murriztea, itzulerako argia ez da hauteman"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+"Bai, automatikoa, begien gorria murriztea, itzulerako argia hauteman da"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Albuma"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumeko artista"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Aspektu-erlazioa"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Egilea"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bit-emaria"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanalak"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Iruzkina"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Deskribatzea"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Konposatzailea"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Egile-eskubidea"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Sorrera data"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Iraupena"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Fotograma-abiadura"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokumentu sortzailea da"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Generoa"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altuera"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Irudiaren data eta ordua"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabrikatzailea"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Eredua"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Irudiaren orientazioa"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Gako-hitzak"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Hizkuntza"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Lerro zenbaketa"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Hitzen egilea"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Orri zenbaketa"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Irekiduraren balioa"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Jatorrizko data eta ordua"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Esposizio alborapena"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Esposizio denbora"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F zenbakia"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Foku luzera"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Foku luzera 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS latitudea"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS longitudea"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS altitudea"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO abiadura balioa"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Neurtzeko modua"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X dimentsioa"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y dimentsioa"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Asetasuna"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Garbitasuna"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Zuri-balantzea"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Argitaratzailea"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiketa"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Argitaratze urtea"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Lagin-maiztasuna"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Gaia"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Izenburua"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Aztarna zenbakia"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Disko zenbakia"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Kokalekua"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Interpretatzailea"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Taldea"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Moldatzailea"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Zuzendaria"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Bilduma"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Lizentzia"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Hitzak"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+# 2018-06-11 al: itzulgai berria da eta ez da beste hizkuntzetan itzuli oraindik. Uste det fitxategi/karpeta bati emandako "puntuazio"ari buruz ari dela. Berrikusi itzulpena astebete barru.
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Puntuazioa"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Berriz-jotze irabazia (RG) albumaren gailurra"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Berriz-jotze irabazia (RG) albumaren irabazia"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Berriz-jotze irabazia (RG) aztarnaren gailurra"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Berriz-jotze irabazia (RG) aztarnaren irabazia"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Zabalera"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Hitz zenbaketa"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unitate itzulgarriak"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Itzulpenak"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Zirriborro itzulpenak"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Egilea"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Azken eguneratzea"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Txantiloien sorrera"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Hemendik deskargatua"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-posta eranskindunaren gaia"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-posta eranskindunaren igorlea"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-posta eranskindunaren mezu ID "
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Artxiboa"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audioa"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokumentua"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Irudia"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Aurkezpena"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Kalkulu-orria"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Testua"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Bideoa"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Karpeta"

--- a/po/fi/kfilemetadata5.po
+++ b/po/fi/kfilemetadata5.po
@@ -1,0 +1,827 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Lasse Liehu <lasse.liehu@gmail.com>, 2014, 2015, 2016, 2017.
+# Tommi Nieminen <translator@legisign.org>, 2017, 2018, 2019.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-08-27 20:37+0300\n"
+"Last-Translator: Tommi Nieminen <translator@legisign.org>\n"
+"Language-Team: Finnish <kde-i18n-doc@kde.org>\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 18.12.3\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Ei muutettu"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Käännetty vaakasuunnassa"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Kierretty 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Käännetty pystysuunnassa"
+
+# ImageMagic: transpose = flip image vertically and rotate 90 degrees
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Peilattu ja kierretty vasemmalle"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Vastapäivään 90° kierretty"
+
+# ImageMagick: transverse = flop image horizontally and rotate 270 degrees
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Peilattu ja kierretty oikealle"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Vastapäivään 270° kierretty"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Ei salamaa"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Laukesi"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Laukesi, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Laukesi, havaittiin paluuvalo"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Kyllä, ei lauennut"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Kyllä, pakollinen"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Kyllä, pakollinen, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Kyllä, pakollinen, havaittiin paluuvalo"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Ei, pakollinen"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Ei, ei lauennut, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ei, automaattinen"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Kyllä, automaattinen"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Kyllä, automaattinen, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Kyllä, automaattinen, havaittiin paluuvalo"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Ei salamatoimintoa"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Ei, ei salamatoimintoa"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Kyllä, punasilmäkorjaus"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Kyllä, punasilmäkorjaus, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Kyllä, punasilmäkorjaus, havaittiin paluuvalo"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Kyllä, pakollinen, punasilmäkorjaus"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Kyllä, pakollinen, punasilmäkorjaus, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Kyllä, pakollinen, punasilmäkorjaus, havaittiin paluuvalo"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Ei, punasilmäkorjaus"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Ei, automaattinen, punasilmäkorjaus"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Kyllä, automaattinen, punasilmäkorjaus"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Kyllä, automaattinen, punasilmäkorjaus, ei havaittu paluuvaloa"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Kyllä, automaattinen, punasilmäkorjaus, havaittiin paluuvalo"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Albumi"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumin artisti"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artisti"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Kuvasuhde"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Tekijä"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bittinopeus"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanavien määrä"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentti"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Kuvaus"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Säveltäjä"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Tekijänoikeus"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Luontiaika"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Kesto"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Kuvataajuus"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Asiakirjan loi"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Tyylilaji"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Korkeus"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Kuvan aika ja päivä"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Valmistaja"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Malli"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Kuvan suunta"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Avainsanat"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Kieli"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Rivimäärä"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Sanoittaja"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Sivumäärä"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Aukon arvo"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Alkuperäinen aika ja päivä"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Valotuspoikkeama"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Valotusaika"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Salama"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F-luku"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Polttoväli"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Polttoväli 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS-leveysaste"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS-pituusaste"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS-korkeustieto"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO-nopeuslukema"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mittaustapa"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X-ulottuvuus"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y-ulottuvuus"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Kylläisyys"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Terävyys"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Valkotasapaino"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Julkaisija"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Nimiö"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Julkaisuvuosi"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Näytetaajuus"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Aihe"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Otsikko"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Kappaleen numero"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Levyn numero"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Paikka"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Esittäjä"
+
+# Tässä on tarkoituksella vältetty sanaa ”yhtye”
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Kokoonpano"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Sovittaja"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Kapellimestari"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kokoelma"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Lisenssi"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Sanat"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Arvostelu"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "ReplayGain: albumin huippu"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "ReplayGain: kappaleen huippu"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Leveys"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Sanamäärä"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Käännösyksiköitä"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Käännöksiä"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Luonnoskäännöksiä"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Tekijä"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Päivitetty viimeksi"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Mallin luontiaika"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Ladattu lähteestä"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Sähköpostiliitteen aihe"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Sähköpostiliitteen lähettäjä"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Sähköpostiliitteen viestitunniste"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arkisto"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Äänitiedosto"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Asiakirja"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Kuva"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Esitys"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Laskentataulukko"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Teksti"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Kansio"

--- a/po/fr/kfilemetadata5.po
+++ b/po/fr/kfilemetadata5.po
@@ -1,0 +1,827 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Vincent PINON <vpinon@kde.org>, 2014, 2016, 2017.
+# Sebastien Renard <renard@kde.org>, 2014, 2015.
+# Simon Depiets <sdepiets@gmail.com>, 2017, 2018, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-07-21 11:28+0800\n"
+"Last-Translator: Simon Depiets <sdepiets@gmail.com>\n"
+"Language-Team: French <kde-francophone@kde.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Lokalize 19.07.70\n"
+"X-Environment: kde\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Inchangé"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Retournement horizontal"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rotation de 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Retournement vertical"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposée"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Rotation antihoraire de 90°"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Diagonale"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Rotation antihoraire de 270°"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Pas de flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Déclenché"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Déclenché, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Déclenché, lumière réfléchie détectée"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Oui, non déclenché"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Oui, forcé"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Oui, forcé, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Oui, forcé, lumière réfléchie détectée"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Non, forcé"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Non, non déclenché, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Non, automatique"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Oui, automatique"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Oui, automatique, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Oui, automatique, lumière réfléchie détectée"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Pas de fonction flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Non, pas de fonction flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Oui, anti yeux rouges"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Oui, anti yeux rouges, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Oui, anti yeux rouges, lumière réfléchie détectée"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Oui, forcé, anti yeux rouges"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Oui, forcé, anti yeux rouges, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Oui, forcé, anti yeux rouges, lumière réfléchie détectée"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Non, anti yeux rouges"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Oui, automatique, anti yeux rouges"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Oui, automatique, anti yeux rouges"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Oui, automatique, anti yeux rouges, lumière réfléchie non détectée"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Oui, automatique, anti yeux rouges, lumière réfléchie détectée"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 ips"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artiste de l'album"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artiste"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Rapport d'affichage"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Auteur"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Débit"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canaux"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Commentaire"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Description"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositeur"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Date de création"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Durée"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Fréquence d'image"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Document généré par"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Hauteur"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Date et heure de l'image"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modèle"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientation de l'image"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Mots clés"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Langue"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Nombre de lignes"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Parolier"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Nombre de pages"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Ouverture de l'objectif"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Date et heure de l'original"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Correction de l'exposition"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Temps d'exposition"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Nombre F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Longueur focale"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Longueur focale 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitude GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitude GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitude GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Vitesse ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mode de mesure"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimension X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimension Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturation"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Netteté"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balance des blancs"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Éditeur"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Label"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Année de publication"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Taux d'échantillonnage"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Sujet"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titre"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Numéro de piste"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Numéro du disque"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Lieu"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Auteur"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangeur"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Chef d'orchestre"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilation"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licence"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Paroles"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Note"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Pic « Replay Gain » de l'album"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Gain « Replay Gain » de l'album"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pic « Replay Gain » de la piste"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Gain « Replay Gain » de la piste"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Largeur"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Nombre de mots"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unités qui peuvent être traduites"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traductions"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traductions brouillons"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Auteur"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Dernière mise à jour"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Modèle de création"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Téléchargé depuis"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Sujet du courriel de la pièce jointe"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Expéditeur du courriel de la pièce jointe"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Identifiant de message du courriel de la pièce jointe"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archive"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Document"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Image"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Présentation"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Tableur"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Texte"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vidéo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Dossier"

--- a/po/gd/kfilemetadata5.po
+++ b/po/gd/kfilemetadata5.po
@@ -1,0 +1,876 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# GunChleoc <fios@foramnagaidhlig.net>, 2015, 2016.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2016-04-29 19:43+0100\n"
+"Last-Translator: GunChleoc <fios@foramnagaidhlig.net>\n"
+"Language-Team: Fòram na Gàidhlig\n"
+"Language: gd\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : "
+"(n > 2 && n < 20) ? 2 : 3;\n"
+"X-Generator: Virtaal 0.7.1\n"
+"X-Project-Style: kde\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Eadar-theangachaidhean"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Solas-boillsgidh an deilbh"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Albam"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Neach-ciùil an albaim"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Neach-ciùil"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Co-mheas an deilbh"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Ùghdar"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Astar nam biod"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Seanailean"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Beachd"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "Faid"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Sgrìobhaiche ciùil"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Còir-lethbhreac"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Ceann-là a' chruthachaidh"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Faid"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Astar nam frèam"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Gnè"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Àirde"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Ceann-là 's àm an deilbh"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modail an deilbh"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Comhair an deilbh"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Facalan-luirg"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Cànan"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Cunntadh loidhnichean"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Sgrìobhaiche fhaclan"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Cunntadh dhuilleagan"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Luach fosgladh an deilbh"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Ceann-là 's àm tùsail an deilbh"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Leasachadh deisearas an deilbh"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Ùine deisearas an deilbh"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Solas-boillsgidh an deilbh"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Àireamh an traca"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Faid fòcas an deilbh"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Faid fòcas 35mm an deilbh"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Domhan-leud GPS an deilbh"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Domhan-fhad GPS an deilbh"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Àirde GPS an deilbh"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Rangachadh astar ISO an deilbh"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Modh meatairigeadh an deilbh"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimeinsean X an deilbh"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimeinsean Y an deilbh"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Faid"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Geurad an deilbh"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Cothromachadh gile an deilbh"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Foillsichear"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Bliadhna an sgaoilidh"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Reat shampallan"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Cuspair"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Tiotal"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Àireamh an traca"
+
+#: src/propertyinfo.cpp:388
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Àireamh an traca"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "Faid"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Sgrìobhaiche fhaclan"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Leud"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Cunntadh fhaclan"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Aonadan a ghabhas eadar-theangachadh"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Eadar-theangachaidhean"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Dreachdan eadar-theangachaidhean"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Ùghdar"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "An t-ùrachadh mu dheireadh"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Cruthachadh teamplaide"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Air a luchdadh a-nuas o"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Cuspair a' cheanglachain puist-d"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Seòladair a' cheanglachain puist-d"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID teachdaireachd a' cheanglachain puist-d"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Tasg-lann"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Fuaim"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Sgrìobhainn"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Dealbh"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Taisbeanadh"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Cliath-dhuilleag"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Teacsa"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Pasgan"

--- a/po/gl/kfilemetadata5.po
+++ b/po/gl/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Marce Villarino <mvillarino@kde-espana.org>, 2014.
+# Adrián Chaves Fernández <adriyetichaves@gmail.com>, 2015, 2016, 2017.
+# Adrián Chaves (Gallaecio) <adrian@chaves.io>, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-07-13 17:05+0200\n"
+"Last-Translator: Adrián Chaves (Gallaecio) <adrian@chaves.io>\n"
+"Language-Team: Galician <kde-i18n-doc@kde.org>\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Non cambiada"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Invertida horizontalmente"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rotada 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Invertida verticalmente"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposta"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° antihorarios"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Oblicuo"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° antihorarios"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Sen flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Disparado"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Disparado, sen luz de retorno"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Disparado, con luz de retorno"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Si, non se disparou"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Si, obrigatorio"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Si, obrigatorio, sen luz de retorno"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Si, obrigatorio, con luz de retorno"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Non, obrigatorio"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Non, non se disparou, sen luz de retorno"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, automático"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Si, automático"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Si, automático, sen luz de retorno"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Si, automático, con luz de retorno"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Sen función de flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Non, sen función de flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Si, redución de ollos vermellos"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Si, redución de ollos vermellos, sen luz de retorno"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Si, redución de ollos vermellos, con luz de retorno"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Si, obrigatorio, redución de ollos vermellos"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Si, obrigatorio, redución de ollos vermellos, sen luz de retorno"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Si, obrigatorio, redución de ollos vermellos, con luz de retorno"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Non, redución de ollos vermellos"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Non, automático, redución de ollos vermellos"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Si, automático, redución de ollos vermellos"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Si, automático, redución de ollos vermellos, sen luz de retorno"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Si, automático, redución de ollos vermellos, con luz de retorno"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Descoñecido"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Álbum"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista do álbum"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proporcións"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Taxa de bits"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canles"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentario"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descrición"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data de creación"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duración"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Taxa de fotogramas"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Documento xerado por"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Xénero"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altura"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data e hora das imaxes"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modelo"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientación da imaxe"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Palabras clave"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Número de liñas"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Letrista"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Número de páxinas"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor de abertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Data e hora orixinais"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Nesgo da exposición"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Tempo de exposición"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Número F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distancia focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distancia focal 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitude GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Lonxitude GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitude GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Velocidade ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Método de medición"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Tamaño X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Tamaño Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturación"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Focalización"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balance de brancos"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editor"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiqueta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Ano de publicación"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Taxa de mostraxe"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Asunto"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Título"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Número de pista"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Número de disco"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Lugar"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Conxunto"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranxos"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Condutor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilación"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licenza"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Letra"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Cualificación"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Pico de percepción de volume do álbum"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Ganancia de percepción de volume do álbum"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pico de percepción de volume da pista"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Ganancia de percepción de volume da pista"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Anchura"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Cantidade de palabras"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unidades traducíbeis"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traducións"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Esbozos de tradución"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Última actualización"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Creación de modelos"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Descargado de"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Asunto da mensaxe do anexo"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Remitente da mensaxe do anexo"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Identificador da mensaxe do anexo"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arquivo"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Son"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Documento"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imaxe"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentación"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Folla de cálculo"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Texto"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Cartafol"

--- a/po/hu/kfilemetadata5.po
+++ b/po/hu/kfilemetadata5.po
@@ -1,0 +1,866 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Balázs Úr <urbalazs@gmail.com>, 2014.
+# Kristóf Kiszel <ulysses@kubuntu.org>, 2014, 2015.
+# Kristof Kiszel <kiszel.kristof@gmail.com>, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2018-10-23 19:00+0200\n"
+"Last-Translator: Kristof Kiszel <kiszel.kristof@gmail.com>\n"
+"Language-Team: Hungarian <kde-l10n-hu@kde.org>\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Fordítások"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Fénykép vaku"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Album előadó"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Előadó"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Méretarány"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Szerző"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitsebesség"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Csatornák"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Megjegyzés"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Leírás"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Zeneszerző"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Szerzői jog"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Létrehozás dátuma"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Időtartam"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Képkockaszám"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokumentum létrehozója"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Műfaj"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Magasság"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Kép dátum és idő"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Kép modell"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Kép tájolása"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Kulcsszavak"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Nyelv"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Sorszám"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Lírikus"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Oldalszám"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Fénykép apertúraérték"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Fénykép eredeti dátum és idő"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Fénykép expozíció torzítás"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Fénykép exponálási idő"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Fénykép vaku"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Lemez sorszám"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Fénykép fókusztávolság"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Fénykép 35mm fókusztávolság"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Fénykép GPS szélesség"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Fénykép GPS hosszúság"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Fénykép GPS magasság"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Fénykép ISO-sebesség arány"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Fénykép mérési mód"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Fénykép X dimenzió"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Fénykép Y dimenzió"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Időtartam"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Fénykép élesség"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Fénykép fehéregyensúly"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Kiadó"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Címke"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Kiadás éve"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Mintavételezési ráta"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Tárgy"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Cím"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Sorszám"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Lemez sorszám"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Hely"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Előadó"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Együttes"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Rendező"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Karmester"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Gyűjtemény"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licenc"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Dalszöveg"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Pontszám"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Album hangerőállításának csúcsa"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Album erősítési tényezője"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Szám hangerőállításának csúcsa"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Szám erősítési tényezője"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Szélesség"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Szavak száma"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Fordítható egységek"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Fordítások"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Félkész fordítások"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Szerző"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Utolsó frissítés"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Sablon létrehozása"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Letöltve innen"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-mail tárgya"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-mail feladója"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-mail üzenetazonosítója"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archívum"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Hang"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokumentum"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Kép"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Bemutató"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Munkafüzet"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Szöveg"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Videó"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Mappa"

--- a/po/ia/kfilemetadata5.po
+++ b/po/ia/kfilemetadata5.po
@@ -1,0 +1,825 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Giovanni Sora <g.sora@tioscali.it>, 2014.
+# G.Sora <g.sora@tiscali.it>, 2014, 2016, 2017, 2019, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2020-02-18 19:51+0100\n"
+"Last-Translator: Giovanni Sora <g.sora@tiscali.it>\n"
+"Language-Team: Interlingua <kde-i18n-doc@kde.org>\n"
+"Language: ia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Non modificate"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Colpate horizontalmente"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rotate de 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Colpate verticalmente"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponite"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° rotate CCW "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "De modo oblique"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° rotate CCW"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Necun Fulgor (Flash)"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Tirate"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Tirate, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Tirate, lumine de retorno relevate"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Si, non tirava"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Si, obligatori"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Si, obligatori, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Si, obligatori, lumine de retorno relevate"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "No, obligatori"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "No, non tirava, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, automatic"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Si, automatic"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Si, automatic, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Si, automatic, lumine de retorno relevate"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Necun function de flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "No, necun function de flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Si, reduction de oculo rubie"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Si, reduction de oculo rubie, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Si, reduction de oculo rubie, lumine de retorno relevate"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Si, obligatori, reductin de oculo rubie"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Si, obligatori, reduction de oculo rubie, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Si, obligatori, reduction de oculo rubie, lumine de retorno relevate"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "No, reduction de oculo rubie"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "No, automatic, reduction de oculo rubie"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Si, automatic, reduction de oculo rubie"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Si, automatic, reduction de oculo rubie, lumine de retorno non relevate"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Si, automatic, reduction de oculo rubie, lumine de retorno relevate"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Incognite"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista del album"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proportiones"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Frequentia de bit"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canales"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Commento"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Description"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data de creation"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duration"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Frequentia de photogramma (Frame)"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Documento generate per"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genere"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altessa"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Tempore de data de imagine"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Constructor"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modello"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientation de imagine"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Parolas clave"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Linguage"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Computo de rango"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Scriptor de parolas (Lyricist)"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Computo de pagina"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor de apertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Tempore de data original"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Bias de exposition"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Tempore de exposition"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Fulgor (Flash)"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Numero F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Longitude Focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Longitude Focal 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitude GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitude GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitude de GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Classification de velocitate ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Modo de Metrar"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimension X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimension Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturation"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Acutessa"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balanciamento del blanc"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editor (Publisher)"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiquetta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Anno de liberation"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Frequentia de exemplo"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Subjecto"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titulo"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Numero de tracia"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Numero de disco"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Location"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Executor"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangiator"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Conductor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilation"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licentia:"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Parolas del Canto"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Evalutation"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Picco de album de ganio repetite"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Ganio de album de ganio repetite"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Picco de tracia de ganio repetite"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Ganio de tracia de ganio repetite"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Largessa"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Computo de parola"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unitates traducibile"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traductiones"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traductiones provvisori"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Ultime actualisation"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Creation de patrono"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Discargate ex"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Subject de attachamento de e-posta"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Mittente de attachmento de e-posta"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID de message de attachamento de e-posta"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archivo"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Documento"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imagine"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentation"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Folio de calculo electronic"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Texto"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Dossier"

--- a/po/id/kfilemetadata5.po
+++ b/po/id/kfilemetadata5.po
@@ -1,0 +1,821 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Wantoyo <wantoyek@gmail.com>, 2018, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-07-29 20:03+0700\n"
+"Last-Translator: Wantoyo <wantoyek@gmail.com>\n"
+"Language-Team: Indonesian <kde-i18n-doc@kde.org>\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Takdiubah"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Dijungkir secara mendatar"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Dirotasikan 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Dijungkir secara tegak"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Ditransposisikan"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Dirotasikan 90° LAJJ"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Dilintangkan"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Dirotasikan 270° LAJJ"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Tanpa flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Berapi"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Berapi, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Berapi, cahaya balik terdeteksi"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ya, tidak berapi"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ya, wajib"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ya, wajib, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ya, wajib, cahaya balik terdeteksi"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Tidak, wajib"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Tidak, tidak berapi, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Tidak, auto"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ya, auto"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ya, auto, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ya, auto, cahaya balik terdeteksi"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Tanpa fungsi flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Tidak, tanpa fungsi flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ya, reduksi mata merah"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ya, reduksi mata merah, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ya, reduksi mata merah, cahaya balik terdeteksi"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ya, wajib,reduksi mata merah"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Ya, wajib,reduksi mata merah, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Ya, wajib,reduksi mata merah, cahaya balik terdeteksi"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Tidak, reduksi mata merah"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Tidak, auto, reduksi mata merah"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Ya, auto, reduksi mata merah"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Ya, auto, reduksi mata merah, cahaya balik tidak terdeteksi"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ya, auto, reduksi mata merah, cahaya balik terdeteksi"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Takdiketahui"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Album Artis"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artis"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Segi Perbandingan"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Penulis"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Channel"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Komentar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Deskripsi"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Pencipta"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Hak Cipta"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Tanggal Penciptaan"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Durasi"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Frame Rate"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokumen Dihasilkan Oleh"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Tinggi"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Waktu Tanggal Citra"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Manufaktur"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientasi Citra"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Katakunci"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Bahasa"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Jumlah Garis"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Penulis Lirik"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Jumlah Halaman"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Nilai Bukaan"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Waktu Tanggal Asli"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Bias Paparan"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Waktu Paparan"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Kilat"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Nomor F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Panjang Fokal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Panjang Fokal 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Lintang GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Bujur GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Ketinggian GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Peringkat Kecepatan ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mode Pengukuran"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensi X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensi Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Suram"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Ketajaman"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Keseimbangan Putih"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Pemublikasi"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Label"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Tahun Rilis"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Sample Rate"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Subjek"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Judul"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Nomor Trek"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Nomor Cakram"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Lokasi"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Keartisan"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ansambel"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Penggubah"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Konduktor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompilasi"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Lisensi"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Lirik"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Peringkat"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Gain Replay Puncak Album"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Gain Replay Gain Album"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Gain Replay Puncak Trek"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Gain Replay Gain Trek"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Lebar"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Jumlah Kata"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unit Dapat Diterjemahkan"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Terjemahan"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Terjemahan Draft"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Penulis"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Pembaruan Terakhir"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Penciptaan Template"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Diunduh Dari"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Subjek Pelampiran E-Mail"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Pengirim Pelampiran E-Mail"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID Pesan Pelampiran E-Mail"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arsip"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokumen"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Citra"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentasi"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Lembar-sebar"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Teks"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Folder"

--- a/po/it/kfilemetadata5.po
+++ b/po/it/kfilemetadata5.po
@@ -1,0 +1,828 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Federico Zenith <federico.zenith@member.fsf.org>, 2014.
+# Vincenzo Reale <smart2128vr@gmail.com>, 2015.
+# Paolo Zamponi <zapaolo@email.it>, 2017, 2018.
+# Valter Mura <valtermura@gmail.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-29 12:01+0200\n"
+"Last-Translator: Valter Mura <valtermura@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 19.04.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Non modificata"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Ribaltata orizzontalmente"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rotazione di 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Ribaltata verticalmente"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Trasposta"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Rotazione di 90° in senso antiorario"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Trasversale"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Rotazione di 270° in senso antiorario"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Senza flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Scattato"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Scattato, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Scattato, luce di ritorno rilevata"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Sì, non ha scattato"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Sì, obbligatorio"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Sì, obbligatorio, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Sì, obbligatorio, luce di ritorno rilevata"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "No, obbligatorio"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "No, non ha scattato, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "No, automatico"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Sì, automatico"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Sì, automatico, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Sì, automatico, luce di ritorno rilevata"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Senza funzione di flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "No, senza funzione di flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Sì, riduzione degli occhi rossi"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Sì, riduzione degli occhi rossi, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Sì, riduzione degli occhi rossi, luce di ritorno rilevata"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Sì, obbligatorio, riduzione degli occhi rossi"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Sì, obbligatorio, riduzione degli occhi rossi, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+"Sì, obbligatorio, riduzione degli occhi rossi, luce di ritorno rilevata"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "No, riduzione degli occhi rossi"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "No, automatico, riduzione degli occhi rossi"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Sì, automatico, riduzione degli occhi rossi"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Sì, automatico, riduzione degli occhi rossi, luce di ritorno non rilevata"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Sì, automatico, riduzione degli occhi rossi, luce di ritorno rilevata"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista dell'album"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proporzioni"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autore"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canali"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Commento"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descrizione"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositore"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data di creazione"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Durata"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Frequenza dei fotogrammi"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Documento generato da"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genere"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altezza"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data e ora d'immagine"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Produttore"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modello"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientamento dell'immagine"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Parole chiave"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Lingua"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Conteggio righe"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Paroliere"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Conto delle pagine"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Diaframma"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Data e ora originali"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Compensazione dell'esposizione"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Tempo di esposizione"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Numero F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Lunghezza focale"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Lunghezza focale 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitudine GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitudine GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitudine GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Valore di sensibilità ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Modalità di misurazione"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensione X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensione Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturazione"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Nitidezza"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Bilanciamento del bianco"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editore"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etichetta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Anno di pubblicazione"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Campionamento"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Oggetto"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titolo"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Numero della traccia"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Numero del disco"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Posizione"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Complesso"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangiatore"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Direttore"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Raccolta"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licenza"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Testo"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opera"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Valutazione"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Guadagno di riproduzione - Picco album"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Guadagno di riproduzione - Guadagno album"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Guadagno di riproduzione - Picco traccia"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Guadagno di riproduzione - Guadagno traccia"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Larghezza"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Conto delle parole"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unità traducibili"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traduzioni"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Bozze di traduzione"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autore"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Ultimo aggiornamento"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Creazione modello"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Scaricato da"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Oggetto del messaggio con l'allegato"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Mittente del messaggio con l'allegato"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID del messaggio con l'allegato"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archivio"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Documento"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Immagine"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentazione"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Foglio di calcolo"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Testo"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Cartella"

--- a/po/ja/kfilemetadata5.po
+++ b/po/ja/kfilemetadata5.po
@@ -1,0 +1,858 @@
+# Tomohiro Hyakutake <tomhioo@outlook.jp>, 2019.
+# Fumiaki Okushi <fumiaki.okushi@gmail.com>, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-05-11 17:02-0700\n"
+"Last-Translator: Fumiaki Okushi <fumiaki.okushi@gmail.com>\n"
+"Language-Team: Japanese <kde-jp@kde.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+"X-Generator: Lokalize 19.04.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "未変更"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "左右反転"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° 回転"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "上下反転"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "反時計回りに90°回転"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "反時計回りに270°回転"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "フラッシュなし"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "発光"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "発光,反射光なし"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "発光,反射光あり"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "はい,発光なし"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "はい,強制発光"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "はい,強制発光,反射光なし"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "はい,強制発光,反射光あり"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "いいえ,強制発光"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "いいえ,未発光,反射光なし"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "いいえ,自動発光"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "はい,自動発光"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "はい,自動,反射光なし"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "はい,自動,反射光なし"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "フラッシュ機能なし"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "いいえ,フラッシュ機能なし"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "はい,赤目軽減"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "はい,赤目軽減,反射光なし"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "はい,赤目軽減,反射光あり"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "はい,強制発光,赤目軽減"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "はい,強制発光,赤目軽減,反射光なし"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "はい,強制発光,赤目軽減,反射光あり"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "いいえ,赤目軽減"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "いいえ,自動,赤目軽減"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "はい,自動,赤目軽減"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "はい,自動,赤目軽減,反射光なし"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "はい,自動,赤目軽減,反射光あり"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "不明"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "アルバム"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "アルバムのアーティスト"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "アーティスト"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "アスペクト比"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "作者"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "ビットレート"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "チャネル"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "コメント"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "説明"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "作曲"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "著作権"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "作成日"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "長さ"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "フレームレート"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "ドキュメントの作成元"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "ジャンル"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "高さ"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "画像の日時"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "画像モデル"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "画像の方向"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "キーワード"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "言語"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "作詞"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "ページ数"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "画像の絞り値"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "画像の元の日付"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "画像の露出補正値"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "画像の露光時間"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "画像のフラッシュ"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "ディスク番号"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "焦点距離"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "35mm換算の焦点距離"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "画像の GPS 緯度"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "画像の GPS 経度"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "画像の GPS 高度"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "画像の ISO 感度"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "画像の測光モード"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "画像の有効な幅"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "画像の有効な高さ"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "長さ"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr ""
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "画像のホワイトバランス"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr ""
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "ラベル"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr ""
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "サンプリングレート"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "タイトル"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "トラック番号"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "ディスク番号"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "場所"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "ライセンス"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "歌詞"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "評価"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "幅"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "翻訳"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "作者"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "最終更新"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr ""
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "ダウンロード元"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "アーカイブ"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "音楽"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "文書"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "画像"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "プレゼンテーション"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "表計算"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "テキスト"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "動画"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "フォルダ"

--- a/po/ko/kfilemetadata5.po
+++ b/po/ko/kfilemetadata5.po
@@ -1,0 +1,822 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Shinjo Park <kde@peremen.name>, 2014, 2015, 2016, 2017, 2018, 2019, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2020-04-01 02:00+0200\n"
+"Last-Translator: Shinjo Park <kde@peremen.name>\n"
+"Language-Team: Korean <kde-kr@kde.org>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Lokalize 19.04.3\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/초"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "변경하지 않음"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "수평으로 뒤집음"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° 회전"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "수직으로 뒤집음"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "반전"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "반시계 방향 90° 회전"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "대칭"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "반시계 방향 270° 회전"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "플래시 없음"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "발광됨"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "발광됨, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "발광됨, 반사광 감지됨"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "예, 발광되지 않음"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "예, 강제 발광"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "예, 강제 발광, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "예, 강제 발광, 반사광 감지됨"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "아니요, 강제 발광"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "아니요, 발광되지 않음, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "아니요, 자동"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "예, 자동"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "예, 자동, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "예, 자동, 반사광 감지됨"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "플래시 기능 없음"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "아니요, 플래시 기능 없음"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "예, 적목 감소"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "예, 적목 감소, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "예, 적목 감소, 반사광 감지됨"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "예, 강제 발광, 적목 감소"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "예, 강제 발광, 적목 감소, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "예, 강제 발광, 적목 감소, 반사광 감지됨"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "아니요, 적목 감소"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "아니요, 자동, 적목 감소"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "예, 자동, 적목 감소"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "예, 자동, 적목 감소, 반사광 감지되지 않음"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "예, 자동, 적목 감소, 반사광 감지됨"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1초"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1초"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "앨범"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "앨범 아티스트"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "아티스트"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "종횡 비율"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "작성자"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "비트 전송률"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "채널"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "설명"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "설명"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "작곡가"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "저작권"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "만든 날짜"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "시간"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "초당 프레임 수"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "문서 생성자/도구"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "장르"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "높이"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "그림 날짜와 시간"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "제조사"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "모델"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "그림 방향"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "키워드"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "언어"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "줄 수"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "작사자"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "쪽 수"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "조리개 값"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "원본 날짜와 시간"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "노출 보정"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "노출 시간"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "플래시"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F 번호"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "초점 거리"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "35mm 환산 초점 거리"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS 위도"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS 경도"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS 고도"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO 감도"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "측량 모드"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X 크기"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y 크기"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "채도"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "선명도"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "화이트 밸런스"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "출판사"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "레이블"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "발매 연도"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "샘플 레이트"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "주제"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "제목"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "트랙 번호"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "디스크 번호"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "위치"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "공연자"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "앙상블"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "기획자"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "지휘자"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "모음집"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "라이선스"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "작사자"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "작품"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "별점"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "리플레이게인 앨범 피크"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "리플레이게인 앨범 게인"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "리플레이게인 트랙 피크"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "리플레이게인 트랙 게인"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "너비"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "단어 수"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "총 번역 단위 수"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "번역문 수"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "불분명한 번역문 수"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "번역자"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "마지막 수정"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "템플릿 생성 시간"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "다운로드한 위치"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "이메일 첨부 제목"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "이메일 첨부 보낸 사람"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "이메일 첨부 메시지 ID"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "보관"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "오디오"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "문서"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "그림"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "프레젠테이션"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "스프레드시트"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "텍스트"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "동영상"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "폴더"

--- a/po/lt/kfilemetadata5.po
+++ b/po/lt/kfilemetadata5.po
@@ -1,0 +1,826 @@
+# Lithuanian translations for l package.
+# Copyright (C) 2014 This_file_is_part_of_KDE
+# This file is distributed under the same license as the l package.
+#
+# Automatically generated, 2014.
+# Liudas Ališauskas <liudas@aksioma.lt>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: l 10n\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-09-07 19:58+0300\n"
+"Last-Translator: Moo\n"
+"Language-Team: Lithuanian <kde-i18n-lt@kde.org>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n%10>=2 && (n%100<10 || n"
+"%100>=20) ? 1 : n%10==0 || (n%100>10 && n%100<20) ? 2 : 3);\n"
+"X-Generator: Poedit 2.2.1\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/sek."
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Nepakeista"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Horizontaliai apversta"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Pasukta 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Vertikaliai apversta"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponuota"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Pasukta 90° prieš laikrodžio rodyklę "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Skersinė"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Pasukta 270° prieš laikrodžio rodyklę"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Be blykstės"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Suveikė"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Suveikė, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Suveikė, grįžtamoji šviesa aptikta"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Taip, nesuveikė"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Taip, priverstinė"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Taip, priverstinė, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Taip, priverstinė, grįžtamoji šviesa aptikta"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Ne, privaloma"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Ne, nesuveikė, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ne, automatiškai"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Taip, automatiškai"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Taip, automatiškai, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Taip, automatiškai, grįžtamoji šviesa aptikta"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Be blykstės funkcijos"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Ne, be blykstės funkcijos"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Taip, raudonų akių mažinimas"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Taip, raudonų akių mažinimas, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Taip, raudonų akių mažinimas, grįžtamoji šviesa aptikta"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Taip, privaloma, raudonų akių mažinimas"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Taip, privaloma, raudonų akių mažinimas, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Taip, privaloma, raudonų akių mažinimas, grįžtamoji šviesa aptikta"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Ne, raudonų akių mažinimas"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Ne, automatiškai, raudonų akių mažinimas"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Taip, automatiškai, raudonų akių mažinimas"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Taip, automatiškai, raudonų akių mažinimas, grįžtamoji šviesa neaptikta"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Taip, automatiškai, raudonų akių mažinimas, grįžtamoji šviesa aptikta"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 kadr./sek."
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 sek."
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 sek."
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Albumas"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumo atlikėjas"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Atlikėjas"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proporcijos"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autorius"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Pralaidumas"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanalai"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Komentaras"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Aprašas"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Kompozitorius"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Autorių teisės"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Sukūrimo data"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Trukmė"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Kadrų dažnis"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokumentą sukūrė"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Žanras"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Aukštis"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Paveikslo data ir laikas"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Gamintojas"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modelis"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Paveikslo orientacija"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Raktažodžiai"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Kalba"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Eilučių skaičius"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Žodžių autorius"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Puslapių skaičius"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Diafragmos reikšmė"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Pradinė data ir laikas"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Išlaikymo nuokrypis"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Išlaikymo trukmė"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blykstė"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F skaičius"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Židinio nuotolis"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Židinio nuotolis 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS platuma"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS ilguma"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS aukštis"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO greičio įvertinimas"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Matavimo veiksena"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X matmuo"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y matmuo"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Grynis"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Ryškumas"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Baltos spalvos balansas"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Leidėjas"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etiketė"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Išleidimo metai"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Skaitmeninimo dažnis"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Tema"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Pavadinimas"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Takelio numeris"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Disko numeris"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Vieta"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Atlikėjas"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ansamblis"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranžuotojas"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigentas"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompiliacija"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licencija"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Dainos žodžiai"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Įvertinimas"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Replay Gain albumo viršūnė"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Replay Gain albumo stiprinimas"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Replay Gain takelio viršūnė"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Replay Gain takelio stiprinimas"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Plotis"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Žodžių skaičius"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Verstini vienetai"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Vertimai"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Vertimų juodraščiai"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autorius"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Paskutinis atnaujinimas"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Šablono sukūrimas"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Atsisiųsta iš"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "El. laiško priedo tema"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "El. laiško priedo siuntėjas"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "El. laiško priedo laiško ID"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archyvas"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Garso įrašas"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokumentas"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Paveikslas"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Pateiktis"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Skaičiuoklė"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekstas"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vaizdo įrašas"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Aplankas"

--- a/po/ml/kfilemetadata5.po
+++ b/po/ml/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Malayalam translations for kfilemetadata package.
+# Copyright (C) 2019 This file is copyright:
+# This file is distributed under the same license as the kfilemetadata package.
+# Automatically generated, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-07-19 02:55+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Swathanthra|സ്വതന്ത്ര Malayalam|മലയാളം Computing|കമ്പ്യൂട്ടിങ്ങ് <smc."
+"org.in>\n"
+"Language: ml\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr ""
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr ""
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr ""
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr ""
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr ""
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr ""
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr ""
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr ""
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr ""
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr ""
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr ""
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr ""
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr ""
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr ""
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr ""
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr ""
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr ""
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr ""
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr ""
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr ""
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr ""
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr ""
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr ""
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr ""
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr ""
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr ""
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr ""
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr ""
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr ""
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr ""
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr ""
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr ""
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr ""
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr ""
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr ""
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr ""
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr ""
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr ""
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr ""
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr ""
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr ""
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr ""
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr ""
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr ""
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr ""
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr ""
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr ""
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr ""
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr ""
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr ""
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr ""
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr ""

--- a/po/nb/kfilemetadata5.po
+++ b/po/nb/kfilemetadata5.po
@@ -1,0 +1,824 @@
+# Translation of kfilemetadata5 to Norwegian Bokmål
+#
+# Bjørn Steensrud <bjornst@skogkatt.homelinux.org>, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2014-11-05 13:42+0100\n"
+"Last-Translator: Bjørn Steensrud <bjornst@skogkatt.homelinux.org>\n"
+"Language-Team: Norwegian Bokmål <l10n-no@lister.huftis.org>\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 1.5\n"
+"X-Environment: kde\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr ""
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Album artist"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artist"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Bredde/høyde-forhold"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Forfatter"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanaler"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr ""
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Komponist"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Opphavsrett"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Opprettelsesdato"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Varighet"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Rutefrekvens"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Sjanger"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Høyde"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Dato og klokkeslett"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr ""
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Bilderetning"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Nøkkelord"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Språk"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Antall linjer"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Tekstforfatter"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Antall sider"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr ""
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr ""
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr ""
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr ""
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr ""
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr ""
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr ""
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr ""
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr ""
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr ""
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr ""
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Utgiver"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Slipp-år"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Samplingsrate"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Emne"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Tittel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Spornummer"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr ""
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Artist"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr ""
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Karakter"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Bredde"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Antall ord"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr ""
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr ""
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr ""
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arkiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Lyd"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Bilde"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentasjon"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Regneark"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr ""

--- a/po/nds/kfilemetadata5.po
+++ b/po/nds/kfilemetadata5.po
@@ -1,0 +1,866 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Sönke Dibbern <s_dibbern@web.de>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2014-07-09 21:27+0200\n"
+"Last-Translator: Sönke Dibbern <s_dibbern@web.de>\n"
+"Language-Team: Low Saxon <kde-i18n-nds@kde.org>\n"
+"Language: nds\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 1.4\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Foto Blix"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumkünstler"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Künstler"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proportschonen"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bit-Wedderhalen"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanaals"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Beschrieven"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Schriever"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Opstelldatum"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duer"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Bildwedderhalen"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Oort"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Hööchde"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Bilddatum un -tiet"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Bild Modell"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Bildutrichten"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Slötelwöör"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Spraak"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Regentall"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Textschriever"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Siedentall"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Foto Blenn"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Foto Orginaaldatum un -tiet"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Foto Belichtenafwieken"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Foto Belichtentiet"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Foto Blix"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Spoornummer"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Foto Brennwiet"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Foto Brennwiet 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Foto ISO-Lichtföhlsamkeit"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Foto Meetmetood"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Foto X-Afmeten"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Foto Y-Afmeten"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Duer"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Foto Scharpde"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Foto Wittbalangs"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Apenmaker"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Utgaavjohr"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Aftast-Gauigkeit"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Bedröppt"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Spoornummer"
+
+#: src/propertyinfo.cpp:388
+#, fuzzy, kde-format
+#| msgctxt "@label music track number"
+#| msgid "Track Number"
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Spoornummer"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "Duer"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Textschriever"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Breed"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Wöörtall"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Author"
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr ""
+
+#: src/propertyinfo.cpp:532
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Orientation"
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Bildutrichten"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archiev"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Klang"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokment"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Bild"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentatschoon"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Tabellrekenblatt"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr ""

--- a/po/nl/kfilemetadata5.po
+++ b/po/nl/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Freek de Kruijf <freekdekruijf@kde.nl>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-22 11:20+0200\n"
+"Last-Translator: Freek de Kruijf <freekdekruijf@kde.nl>\n"
+"Language-Team: Dutch <kde-i18n-nl@kde.org>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 19.04.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Ongewijzigd"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Horizontaal gespiegeld"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "180° gedraaid"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Verticaal gespiegeld"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Getransponeerd"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "90° geroteerde CCW "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Kruislings gedraaid"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "270° geroteerde CCW"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Geen flits"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Geflitst"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Afgevuurd, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Afgevuurd, teruggekeerd licht gedetecteerd"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ja, is niet afgevuurd"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ja, vereist"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ja, vereist, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ja, vereist, teruggekeerd licht gedetecteerd"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nee, vereist"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nee, niet afgevuurd, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nee, automatisch"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ja, automatisch"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ja, automatisch, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ja, automatisch, teruggekeerd licht gedetecteerd"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Geen flitsfunctie"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nee, geen flitsfunctie"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ja, rode-ogenreductie"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ja, rode-ogenreductie, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ja, rode-ogenreductie, teruggekeerd licht gedetecteerd"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ja, vereist, rode-ogenreductie"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Ja, vereist, rode-ogenreductie, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Ja, vereist, rode-ogenreductie, teruggekeerd licht gedetecteerd"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nee, rode-ogenreductie"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nee, automatisch, rode-ogenreductie"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Ja, automatisch, rode-ogenreductie"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Ja, automatisch, rode-ogenreductie, teruggekeerd licht niet gedetecteerd"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ja, automatisch, rode-ogenreductie, teruggekeerd licht gedetecteerd"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumartiest"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artiest"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Aspectverhouding"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Auteur"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitsnelheid"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanalen"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Toelichting"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Beschrijving"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Opsteller"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Aanmaakdatum"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duur"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Framesnelheid"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Document gegenereerd door"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Hoogte"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Datum en tijd van afbeelding"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabrikant"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Oriëntatie van de afbeelding"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Trefwoorden"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Taal"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Aantal regels"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Maker liedtekst"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Aantal pagina's"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Diafragmawaarde"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Oorspronkelijke datum tijd"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Belichtingsbasis"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Belichtingstijd"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flits"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F-getal"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Brandpuntsafstand"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Brandpuntsafstand 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS breedtegraad"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS lengtegraad"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS hoogte"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO-snelheid"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Lichtmetingsmodus"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X-afmeting"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y-afmeting"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Verzadiging"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Scherpte"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Witbalans"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Uitgever"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Label"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Jaar van uitgave"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Samplesnelheid"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Onderwerp"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Tracknummer"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Schijfnummer"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Locatie"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Performer"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangeur"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilatie"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licentie"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Liedtekst"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Waardering"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Afspeelversterking van albumpiek"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Afspeelversterking van albumversterking"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Afspeelversterking van trackpiek"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Afspeelversterking van trackversterking"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Breedte"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Aantal woorden"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Vertaalbare eenheden"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Vertalingen"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Concept vertalingen"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Auteur"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Laatste keer bijwerken"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Maken van sjabloon"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Gedownload van"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Onderwerp van e-mailbijlage"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Afzender van e-mailbijlage"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Message-ID van e-mailbijlage"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archief"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Geluid"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Document"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Afbeelding"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentatie"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Rekenblad"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Map"

--- a/po/nn/kfilemetadata5.po
+++ b/po/nn/kfilemetadata5.po
@@ -1,0 +1,824 @@
+# Translation of kfilemetadata5 to Norwegian Nynorsk
+#
+# Karl Ove Hufthammer <karl@huftis.org>, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-26 22:02+0200\n"
+"Last-Translator: Karl Ove Hufthammer <karl@huftis.org>\n"
+"Language-Team: Norwegian Nynorsk <l10n-no@lister.huftis.org>\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 19.04.2\n"
+"X-Environment: kde\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Uendra"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Spegla vassrett"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Dreia 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Spegla loddrett"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponert"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Dreia 90° mot klokka"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transvers"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Dreia 270° mot klokka"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Utan blits"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Utløyst"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Utløyst, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Utløyst, returlys oppdaga"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ja, men vart ikkje utløyst"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ja, obligatorisk"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ja, obligatorisk, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ja, obligatorisk, returlys oppdaga"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nei, obligatorisk"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nei, ikkje utløyst, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nei, automatisk"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ja, automatisk"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ja, automatisk, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ja, automatisk, returlys oppdaga"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Manglar blits"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nei, manglar blits"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ja, raudauge-reduksjon"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ja, Ja, raudauge-reduksjon, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ja, Ja, raudauge-reduksjon, returlys oppdaga"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ja, obligatorisk, raudauge-reduksjon"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Ja, obligatorisk, raudauge-reduksjon, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Ja, obligatorisk, raudauge-reduksjon, returlys oppdaga"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nei, raudauge-reduksjon"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nei, automatisk, raudauge-reduksjon"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Ja, automatisk, raudauge-reduksjon"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Ja, automatisk, raudauge-reduksjon, returlys ikkje oppdaga"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ja, automatisk, raudauge-reduksjon, returlys oppdaga"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Ukjend"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 b/s"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumartist"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artist"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Breidd/høgd-forhold"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Forfattar"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanalar"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Merknad"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Skildring"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Komponist"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Opphavsrett"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Opprettingsdato"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Tid"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Bilete per sekund"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument generert av"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Sjanger"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Høgd"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Bilete: dato og klokkeslett"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Produsent"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modell"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Biletretning"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Nøkkelord"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Språk"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Linjetal"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Tekstforfattar"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Sidetal"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Blenderopning"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Opphavleg dato og klokkeslett"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Eksponeringsbias"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Lukkartid"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blits"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F-nummer"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Brennvidd"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Brennvidd 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS-breiddegrad"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS-lengdegrad"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS-høgd"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO-verdi"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Lysmåling"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Vassrett oppløysing"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Loddrett oppløysing"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Fargemetting"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Skarpleik"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Kvitbalanse"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Utgjevar"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Merkelapp"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Utgjevingsår"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Samplingsrate"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Emne"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Tittel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Spornummer"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Platenummer"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Plassering"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Utøvar"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Gruppe"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangert av"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Samling"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Lisens"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Songtekst"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Karakter"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Album-lydtopp (ReplayGain)"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Album-forsterking (ReplayGain)"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Spor-lydtopp (ReplayGain)"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Spor-forsterking (ReplayGain)"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Breidd"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Ordteljing"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Omsetbare einingar"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Omsetjingar"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Omsetjingsframlegg"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Forfattar"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Sist oppdatert"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Mal oppretta"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Lasta ned frå"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Emne til e-postvedlegg"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Avsendar av e-postvedlegg"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Meldings-ID til e-postvedlegg"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arkiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Lyd"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Bilete"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentasjon"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Rekneark"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Mappe"

--- a/po/pa/kfilemetadata5.po
+++ b/po/pa/kfilemetadata5.po
@@ -1,0 +1,824 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# A S Alam <aalam@users.sf.net>, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2014-03-16 23:42-0500\n"
+"Last-Translator: A S Alam <aalam@users.sf.net>\n"
+"Language-Team: Punjabi/Panjabi <punjabi-users@lists.sf.net>\n"
+"Language: pa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr ""
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr ""
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "ਐਲਬਮ"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "ਐਲਬਮ ਕਲਾਕਾਰ"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "ਕਲਾਕਾਰ"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr ""
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "ਲੇਖਕ"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr ""
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "ਚੈਨਲ"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr ""
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr ""
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr ""
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr ""
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr ""
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr ""
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr ""
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr ""
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr ""
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr ""
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr ""
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr ""
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr ""
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr ""
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr ""
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr ""
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr ""
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr ""
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr ""
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr ""
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr ""
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr ""
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr ""
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr ""
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr ""
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr ""
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr ""
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr ""
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr ""
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr ""
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr ""
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr ""
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr ""
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr ""
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr ""
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr ""
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr ""
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr ""
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr ""
+
+#: src/propertyinfo.cpp:517
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Author"
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "ਲੇਖਕ"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr ""
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr ""
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr ""
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr ""
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr ""
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr ""
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr ""
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr ""
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr ""
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr ""
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr ""

--- a/po/pl/kfilemetadata5.po
+++ b/po/pl/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Łukasz Wojniłowicz <lukasz.wojnilowicz@gmail.com>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-22 07:14+0200\n"
+"Last-Translator: Łukasz Wojniłowicz <lukasz.wojnilowicz@gmail.com>\n"
+"Language-Team: Polish <kde-i18n-doc@kde.org>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Lokalize 19.07.70\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Niezmienione"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Odbite w poziomie"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "obrócone o 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Odbite w pionie"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponowane"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "obrócone o 90° w lewo"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Trawersowane"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "obrócone o 270° w lewo"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Bez lampy błyskowej"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Z lampą"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Z lampą, bez światła powrotnego"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Z lampą, ze światłem powrotnym"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Tak, bez lampy"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Tak, wymuszone"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Tak, wymuszone, bez światła powrotnego"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Tak, wymuszone, ze światłem powrotnym"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nie, wymuszone"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nie, bez lampy, bez światła powrotnego"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nie, samoczynnie"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Tak, samoczynnie"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Tak, samoczynnie, bez światła powrotnego"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Tak, samoczynnie, ze światłem powrotnym"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Brak lampy błyskowej"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nie, brak lampy błyskowej"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Tak, ograniczenie czerwonych oczu"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Tak, ograniczenie czerwonych oczu, bez światła powrotnego"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Tak, ograniczenie czerwonych oczu, ze światłem powrotnym"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Tak, wymuszone, ograniczenie czerwonych oczu"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Tak, wymuszone, ograniczenie czerwonych oczu, bez światła powrotnego"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Tak, wymuszone, ograniczenie czerwonych oczu, ze światłem powrotnym"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nie, ograniczenie czerwonych oczu"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nie, samoczynnie, ograniczenie czerwonych oczu"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Tak, samoczynnie, ograniczenie czerwonych oczu"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Tak, samoczynnie, ograniczenie czerwonych oczu, bez światła powrotnego"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Tak, samoczynnie, ograniczenie czerwonych oczu, ze światłem powrotnym"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Nieznany"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 kl./s"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Wykonawca albumu"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Wykonawca"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Współczynnik kształtu"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Szybkość transmisji"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanały"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Komentarz"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Opis"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Kompozytor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Prawa autorskie"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data utworzenia"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Czas trwania"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Liczba klatek na sekundę"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument utworzony przez"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Rodzaj"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Wysokość"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data i czas obrazu"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Wytwórca"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Kierunek obrazu"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Słowa kluczowe"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Język"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Liczba wierszy"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Słowa"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Liczba stron"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Wartość przysłony"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Pierwotna data i czas"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Ukierunkowanie naświetlania"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Czas naświetlenia"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Lampa błyskowa"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Liczba F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Ogniskowa"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Ogniskowa 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Szerokość geograficzna GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Długość geograficzna GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Wysokość GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Wskaźnik ISO szybkości zdjęcia"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Tryb pomiaru"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Wymiar X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Wymiar Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Nasycenie"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Ostrość"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Równowaga bieli"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Wydawca"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etykieta"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Rok wydania"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Próbkowanie"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Temat"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Tytuł"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Numer utworu"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Numer dysku"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Położenie"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Wykonawca"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Zespół"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranżer"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Prowadzący"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompilacja"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licencja"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Słowa"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Ocena"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Szczyt replay gain albumu"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Wzmocnienie replay gain albumu"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Szczyt replay gain utworu"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Wzmocnienie replay gain utworu"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Szerokość"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Liczba słów"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Jednostki do przetłumaczenia"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Tłumaczenia"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Szkic tłumaczenia"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Ostatnie uaktualnienie"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Tworzenie szablonu"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Pobrano z"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Temat wiadomości z załącznikiem"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Nadawca wiadomości z załącznikiem"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID wiadomości z załącznikiem"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archiwum"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Dźwięk"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Obraz"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Prezentacja"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Arkusz kalkulacyjny"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Wideo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Katalog"

--- a/po/pt/kfilemetadata5.po
+++ b/po/pt/kfilemetadata5.po
@@ -1,0 +1,826 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-22 10:34+0100\n"
+"Last-Translator: José Nuno Coelho Pires <zepires@gmail.com>\n"
+"Language-Team: Portuguese <kde-i18n-pt@kde.org>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-POFile-SpellExtra: Flash WriterPlugin JSON ips Transversa EV\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Inalterada"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Invertida na horizontal"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rodada em 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Invertida na vertical"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposta"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Rotação anti-horária em 90° "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transversa"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Rotação anti-horária em 270° "
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Sem 'flash'"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Disparado"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Disparado, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Disparado, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Sim, não disparou"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Sim, compulsivo"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Sim, compulsivo, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Sim, compulsivo, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Não, compulsivo"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Não, não disparou, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Não, automático"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Sim, automático"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Sim, automático, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Sim, automático, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Sem função de 'flash'"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Não, sem função de 'flash'"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Sim, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Sim, com redução de olhos vermelhos, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Sim, com redução de olhos vermelhos, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Sim, compulsivo, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Sim, compulsivo, com redução de olhos vermelhos, sem detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+"Sim, compulsivo, com redução de olhos vermelhos, com detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Não, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Não, automático, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Sim, automático, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Sim, automático, com redução de olhos vermelhos, sem detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+"Sim, automático, com redução de olhos vermelhos, com detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 ips"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Álbum"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista do Álbum"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proporções de Tamanho"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Taxa de Dados"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canais"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentário"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descrição"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Direitos de Cópia"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data de Criação"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duração"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Taxa de Imagens"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Documento Gerado Por"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Género"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altura"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data/Hora da Imagem"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modelo"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientação da Imagem"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Palavras-Chave"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Língua"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Número de Linhas"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Escritor de Letras"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Número de Páginas"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor da Abertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Data/Hora Original"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Peso de Exposição"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Tempo de Exposição"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Número F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distância Focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distância Focal a 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitude do GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitude do GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitude do GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Velocidade ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Modo de Medida"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensão em X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensão em Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturação"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Nitidez"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balanceamento de Branco"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Publicador"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Editora"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Ano de Lançamento"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Taxa de Amostragem"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Assunto"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Título"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Número da Faixa"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Número do Disco"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Localização"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Desempenho"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Conjunto"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranjos"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Condutor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilação"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licença"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Letras Musicais"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Classificação"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Pico do Álbum no Ganho de Reprodução"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Ganho do Álbum no Ganho de Reprodução"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pico da Faixa no Ganho de Reprodução"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Ganho da Faixa no Ganho de Reprodução"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Largura"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Número de Palavras"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unidades a Traduzir"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traduções"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traduções em Rascunho"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Actualizado Em"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Criação do Modelo"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Transferido De"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Assunto do Anexo do E-Mail"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Remetente do Anexo do E-Mail"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID da Mensagem do Anexo do E-Mail"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arquivo"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Áudio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Documento"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imagem"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Apresentação"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Folha de Cálculo"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Texto"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Pasta"

--- a/po/pt_BR/kfilemetadata5.po
+++ b/po/pt_BR/kfilemetadata5.po
@@ -1,0 +1,832 @@
+# Translation of kfilemetadata5.po to Brazilian Portuguese
+# Copyright (C) 2014-2019 This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# André Marcelo Alvarenga <alvarenga@kde.org>, 2014, 2015, 2016, 2018, 2019.
+# Luiz Fernando Ranghetti <elchevive@opensuse.org>, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata5\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-28 00:13-0300\n"
+"Last-Translator: André Marcelo Alvarenga <alvarenga@kde.org>\n"
+"Language-Team: Brazilian Portuguese <kde-i18n-pt_br@kde.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Lokalize 19.04.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Não alterada"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Invertida horizontalmente"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Rotacionada em 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Invertida verticalmente"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transposta"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Rotação anti-horária em 90°"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Transversa"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Rotação anti-horária em 270°"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Sem flash"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Disparado"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Disparado, luz de retorno não detectada"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Disparado, luz de retorno detectada"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Sim, não disparou"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Sim, obrigatório"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Sim, obrigatório, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Sim, obrigatório, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Não, obrigatório"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Não, não disparou, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Não, automático"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Sim, automático"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Sim, automático, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Sim, automático, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Sem função de flash"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Não, sem função de flash"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Sim, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Sim, com redução de olhos vermelhos, sem detecção da luz de retorno"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Sim, com redução de olhos vermelhos, com detecção da luz de retorno"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Sim, obrigatório, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Sim, obrigatório, com redução de olhos vermelhos, sem detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+"Sim, obrigatório, com redução de olhos vermelhos, com detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Não, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Não, automático, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Sim, automático, com redução de olhos vermelhos"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Sim, automático, com redução de olhos vermelhos, sem detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+"Sim, automático, com redução de olhos vermelhos, com detecção da luz de "
+"retorno"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Álbum"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Artista do álbum"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Taxa de proporção"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Taxa de bits"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canais"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentário"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descrição"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compositor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Direitos autorais"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data de criação"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Duração"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Taxa de quadros"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Documento gerado por"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Gênero"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Altura"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Data e hora da imagem"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modelo"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientação da imagem"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Palavras-chave"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Número de linhas"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Lírico"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Número de páginas"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valor de abertura"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Data e hora original"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Desvio de exposição"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Tempo de exposição"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Flash"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Número F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distância focal"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distância focal 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitude GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitude GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitude GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Velocidade ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Modo de medição"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensão X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensão Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturação"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Nitidez"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balanceamento de branco"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Editora"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Rótulo"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Ano de lançamento"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Taxa de amostragem"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Assunto"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Título"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Número da faixa"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Número do disco"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Localização"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Artista"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Conjunto"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arranjos"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Condutor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilação"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licença"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Letras"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Avaliação"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Pico do álbum no ganho de reprodução"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Ganho do álbum no ganho de reprodução"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Pico da faixa no ganho de reprodução"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Ganho da faixa no ganho de reprodução"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Largura"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Número de palavras"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unidades a traduzir"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traduções"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Rascunho de traduções"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Última atualização"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Criação do modelo"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Baixado de"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Assunto do anexo do e-mail"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Remetente do anexo do e-mail"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID da mensagem do anexo do e-mail"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arquivamento"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Áudio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Documento"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imagem"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Apresentação"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Planilha"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Texto"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Pasta"

--- a/po/ro/kfilemetadata5.po
+++ b/po/ro/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+# Sergiu Bivol <sergiu@cip.md>, 2015, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2020-09-08 19:37+0100\n"
+"Last-Translator: Sergiu Bivol <sergiu@cip.md>\n"
+"Language-Team: Romanian\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+"X-Generator: Lokalize 19.12.3\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Neschimbată"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transpusă"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Fără bliț"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Activat"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Da, nu s-a activat"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Da, obligatoriu"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nu, obligatoriu"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nu, automat"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 cps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Interpret album"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Interpret"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Raport de aspect"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Rată de biți"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Canale"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Comentariu"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Descriere"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Compozitor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Drept de autor"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Data creării"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Durată"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Rata de cadre"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Document generat de"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Gen"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Înălțime"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Dată și oră imagine"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Producător"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientare imagine"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Cuvinte-cheie"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Limbă"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Număr de linii"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Textier"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Număr pagini"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Valoare diafragmă"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Dată și oră originale"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Tendința de expunere"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Timp de expunere"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Bliț"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Număr F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Distanță focală"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Distanță focală 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Latitudine GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Longitudine GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Altitudine GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Regim de măsurare"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Dimensiunea X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Dimensiunea Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Saturație"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Claritate"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Balanță de alb"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Emitent"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etichetă"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Anul lansării"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Rată de eșantionare"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Subiect"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titlu"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Număr pistă"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Număr disc"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Amplasare"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Interpret"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ansamblu"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranjor"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirijor"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Compilație"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licență"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Versuri"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Evaluare"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Lățime"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Număr de cuvinte"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Unități traductibile"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Traduceri"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Traduceri pe ciornă"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Ultima actualizare"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Creare șablon"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr ""
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr ""
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr ""
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr ""
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arhivă"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Document"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Imagine"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Prezentare"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Foaie de calcul"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Dosar"

--- a/po/ru/kfilemetadata5.po
+++ b/po/ru/kfilemetadata5.po
@@ -1,0 +1,825 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Alexander Potashev <aspotashev@gmail.com>, 2014, 2015, 2016, 2017, 2018, 2019.
+# Nick Shaforostoff <shafff@ukr.net>, 2016.
+# Alexander Yavorsky <kekcuha@gmail.com>, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-30 14:16+0300\n"
+"Last-Translator: Alexander Potashev <aspotashev@gmail.com>\n"
+"Language-Team: Russian <kde-russian@lists.kde.ru>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Lokalize 19.07.70\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/с"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Без изменений"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Отражено по горизонтали"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Повёрнуто на 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Отражено по вертикали"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Отражено относительно главной диагонали"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Повёрнуто на 90°"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Отражено относительно побочной диагонали"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Повёрнуто на 270°"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Нет вспышки"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Сработала"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Сработала, без возвратного света"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Сработала, возвратный свет"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Да, не сработала"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Да, принудительно"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Да, принудительно, без возвратного света"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Да, принудительно, возвратный свет"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Нет, принудительно"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Нет, не сработала, без возвратного света"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Нет, авто"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Да, авто"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Да, авто, без возвратного света"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Да, авто, возвратный свет"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Камера без вспышки"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Нет, камера без вспышки"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Да, «красный глаз»"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Да, «красный глаз», без возвратного света"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Да, «красный глаз», возвратный свет"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Да, принудительно, «красный глаз»"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Да, принудительно, «красный глаз», без возвратного света"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Да, принудительно, «красный глаз», возвратный свет"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Нет, «красный глаз»"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Нет, авто, «красный глаз»"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Да, авто, «красный глаз»"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Да, авто, «красный глаз», без возвратного света"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Да, авто, «красный глаз», возвратный свет"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 мм"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 к/с"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 с"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 с"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Альбом"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Исполнитель альбома"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Исполнитель"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Соотношение сторон"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Автор"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Битрейт"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Число каналов"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Комментарий"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Описание"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Композитор"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Авторские права"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Дата создания"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Продолжительность"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Частота кадров"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Программа, создавшая документ"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Жанр"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Высота"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Дата и время создания"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Производитель"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Модель"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Ориентация изображения"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Ключевые слова"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Язык"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Количество строк"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Автор текста"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Количество страниц"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Значение диафрагмы"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Исходные дата и время"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Экспокоррекция"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Длительность выдержки"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Фотовспышка"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Диафрагменное число"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Фокусное расстояние"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Фокусное расстояние в 35 мм эквиваленте"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Широта по GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Долгота по GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Высота по GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Чувствительность (ISO)"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Экспозамер"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Размер по оси X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Размер по оси Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Насыщенность"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Резкость"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Баланс белого"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Издатель"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Лейбл"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Год выпуска"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Частота дискретизации"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Тема"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Заголовок"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Номер дорожки"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Номер диска"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Местоположение"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Исполнитель"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Группа"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Аранжировщик"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Дирижёр"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Сборник"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Лицензия"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Автор текста"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Сочинение"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Оценка"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Пик громкости альбома"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Громкость альбома"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Пик громкости дорожки"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Громкость дорожки"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Ширина"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Количество слов"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Строк для перевода"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Переведено строк"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Черновых переводов"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Автор"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Последнее обновление"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Дата создания шаблона"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Источник в Интернете"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Тема письма-источника"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Отправитель письма-источника"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Идентификатор письма-источника"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Архив"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Аудиофайл"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Документ"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Изображение"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Презентация"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Электронная таблица"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Текст"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Видеофайл"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Папка"

--- a/po/sk/kfilemetadata5.po
+++ b/po/sk/kfilemetadata5.po
@@ -1,0 +1,821 @@
+# translation of kfilemetadata.po to Slovak
+# Roman Paholik <wizzardsk@gmail.com>, 2014, 2015, 2016, 2019.
+# Matej Mrenica <matejm98mthw@gmail.com>, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-10-18 21:01+0200\n"
+"Last-Translator: Roman Paholík <wizzardsk@gmail.com>\n"
+"Language-Team: Slovak <kde-sk@linux.sk>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 19.04.3\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Nezmenené"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Prevrátene horizontálne"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Otočené o 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Prevrátené vertikálne"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponované"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Otočené o 90° proti smere"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Pretočený"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Otočené o 270° proti smere"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Žiadny blesk"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Vypálené"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Vypálené, spätné svetlo nebolo zistené"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Vypálené, spätné svetlo bolo zistené"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Áno, nevypálil"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Áno, povinný"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Áno, povinný, spätné svetlo nebolo zistené"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Áno, povinný, spätné svetlo bolo zistené"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nie, povinný"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nie, nevypálil, spätné svetlo nebolo zistené"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nie, automaticky"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Áno, automaticky"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Áno, automaticky, protisvetlo nedetekované"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Áno, automaticky, protisvetlo detekované"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Bez funkcie blesku"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nie, bez funkcie blesku"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Áno, redukcia červených očí"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Áno, redukcia červených očí, protisvetlo nedetekované"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Áno, redukcia červených očí, protisvetlo detekované"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Áno, povinný, redukcia červených očí"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "Áno, povinný, redukcia červených očí, spätné svetlo nebolo zistené"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Áno, povinný, redukcia červených očí, spätné svetlo bolo zistené"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nie, redukcia červených očí"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nie, automaticky, redukcia červených očí"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Áno, automaticky, redukcia červených očí"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Áno, automaticky, redukcia červených očí, protisvetlo nedetekované"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Áno, automaticky, redukcia červených očí, protisvetlo detekované"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Neznáme"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Interpret albumu"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Interpret"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Pomer strán"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Dátový tok"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanály"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Komentár"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Popis"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Editor správ"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Autorské práve"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Dátum vytvorenia"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Trvanie"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Snímková frekvencia"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument generovaný (kým)"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Žáner"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Výška"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Dátum a čas obrázku"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Výrobca"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Orientácia obrázku"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Kľúčové slová"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Jazyk"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Počet riadkov"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Textár"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Počet strán"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Hodnota otvoru"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Pôvodný dátum a čas"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Sklon expozície"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Čas expozície"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blesk"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Číslo F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Ohnisková vzdialenosť"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Ohnisková vzdialenosť 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS zemepisná šírka"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS zemepisná dĺžka"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS nadmorská výška"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO hodnota"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Režim merania fotky"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X Rozmer"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y Rozmer"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Nasýtenie"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Ostrosť"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Vyváženie bielej"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Vydavateľ"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Menovka"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Rok vydania"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Vzorkovacia frekvencia"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Predmet"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Názov"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Číslo stopy"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Číslo disku"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Umiestnenie"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Účinkujúci"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Skupina"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranžér"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompilácia"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licencia"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Text piesne"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Hodnotenie"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Replay Gain Album Peak"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Replay Gain Album Gain"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Replay Gain Track Peak"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Replay Gain Track Gain"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Šírka"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Počet slov"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Preložiteľné jednotky"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Preklady"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Návrhy prekladov"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Posledná aktualizácia"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Vytvorenie šablóny"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Stiahnuté z"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Predmet prílohy mailu"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Odosielateľ prílohy mailu"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID správy prílohy mailu"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Archív"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Obrázok"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Prezentácia"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Zošit"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Priečinok"

--- a/po/sl/kfilemetadata5.po
+++ b/po/sl/kfilemetadata5.po
@@ -1,0 +1,834 @@
+# Slovenian translation of kfilemetadata
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Andrej Mernik <andrejm@ubuntu.si>, 2014, 2015, 2016, 2017, 2018.
+# Matjaž Jeran <matjaz.jeran@amis.net>, 2019, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2020-05-24 19:29+0200\n"
+"Last-Translator: Matjaž Jeran <matjaz.jeran@amis.net>\n"
+"Language-Team: Slovenian <lugos-slo@lugos.si>\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Translator: Andrej Mernik <andrejm@ubuntu.si>\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
+"%100==4 ? 3 : 0);\n"
+"X-Generator: Lokalize 19.12.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Nespremenjeno"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Vodoravno obrnjeno"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Zavrteno za 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Navpično obrnjeno"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponirano"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Zasukano za 90° v obratni smeri urinega kazalca "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Prečeno"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Zasukano za 270° v obratni smeri urinega kazalca"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Brez bliskavice"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Bliskavica je blisknila"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Bliskavica je blisknila, a povratna svetloba ni bila zaznana"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Bliskavica je blisknila in povratna svetloba je bila zaznana"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Bliskavica da, a se ni sprožila"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Prisilni blisk"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Prisilni blisk, a povratna svetloba ni bila zaznana"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Prisilni blisk in povratna svetloba je bila zaznana"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Obvezno brez bliskavice"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Bliskavica ni blisknila in povratna svetloba ni bila zaznana"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ne, avtomatsko"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Da, avtomatsko"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Da, avtomatsko, povratna svetloba ni bila zaznana"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Da, avtomatsko in povratna svetloba je bila zaznana"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Brez funkcij bliskavice"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Ne, brez funkcije bliskavice"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Da z zmanjšanjem efekta rdečih oči"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Da, zmanjšanje efekta rdečih oči, povratna svetloba ni bila zaznana"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Da, zmanjšanje efekta rdečih oči, povratna svetloba je bila zaznana"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Prisilni blisk z zmanjšanjem efekta rdečih oči"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Prisilni blisk z zmanjšanjem efekta rdečih oči a povratna svetloba ni bila "
+"zaznana"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+"Prisilni blisk z zmanjšanjem efekta rdečih oči in povratna svetloba je bila "
+"zaznana"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Ne, z zmanjšanjem efekta rdečih oči"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Ne, avtomatsko z zmanjšanjem efekta rdečih oči"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Da, avtomatsko z zmanjšanjem efekta rdečih oči"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Da, avtomatsko z zmanjšanjem efekta rdečih oči a povratna svetloba ni bila "
+"zaznana"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+"Da, avtomatsko z zmanjšanjem efekta rdečih oči in povratna svetloba je bila "
+"zaznana"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Neznano"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Izvajalec albuma"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Izvajalec"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Razmerje"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Avtor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bitna hitrost"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanali"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Opomba"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Opis"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Skladatelj"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Avtorske pravice"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Datum stvaritve"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Trajanje"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Hitrost sličic"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument je ustvaril"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Zvrst"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Višina"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Datum in čas slike"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Proizvajalec"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Model"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Usmerjenost slike"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Ključne besede"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Jezik"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Število vrstic"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Pisec besedila"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Število strani"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Odprtost zaslonke"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Izvirni datum in čas"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Pristranost ekspozicije"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Osvetlitveni čas"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Bliskavica"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Število F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Goriščna razdalja"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Goriščna razdalja za 35 mm format"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Zemljepisna širina"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Zemljepisna dolžina"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Zemljepisna višina fotografije"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Občutljivost ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Način merjenja"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Velikost X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Velikost Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Nasičenost"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Ostrina"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Ravnovesje beline"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Založnik"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Značka"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Leto izdaje"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Hitrost vzorčenja"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Zadeva"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Naslov"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Številka sledi"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Številka diska"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Lokacija"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Izvajalec"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ansambel"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Aranžer"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompilacija"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licenca"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Besedilo pesmi"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Ocena"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Širina"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Število besed"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Prevedljive enote"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Prevodi"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Osnutki prevodov"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Avtor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Zadnja posodobitev"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Predloga ustvarjena"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Prejeto iz"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Zadeva e-sporočila te priloge"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Pošiljatelj e-sporočila te priloge"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID e-sporočila te priloge"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arhiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Zvok"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Slika"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Predstavitev"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Preglednica"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Besedilo"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Mapa"

--- a/po/sr/kfilemetadata5.po
+++ b/po/sr/kfilemetadata5.po
@@ -1,0 +1,873 @@
+# Translation of kfilemetadata5.po into Serbian.
+# Chusslove Illich <caslav.ilic@gmx.net>, 2014, 2015, 2016, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata5\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2017-10-30 23:08+0100\n"
+"Last-Translator: Chusslove Illich <caslav.ilic@gmx.net>\n"
+"Language-Team: Serbian <kde-i18n-sr@kde.org>\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+"X-Environment: kde\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "преводи"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "блиц (слика)"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "албум"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "извођач албума"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "извођач"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "пропорција"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "аутор"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "битски проток"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "канала"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "коментар"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "композитор"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "ауторска права"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "датум стварања"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "број кадрова"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "генератор документа"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "жанр"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "висина"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "датум-време (слика)"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "модел (слика)"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "оријентација (слика)"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "кључне речи"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "језик"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "број редова"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "текстописац"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "број страница"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "вредност бленде (слика)"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "изворни датум-време (слика)"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "отклон експозиције (слика)"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "време експозиције (слика)"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "блиц (слика)"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "број диска"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "фокусна дужина (слика)"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "фокусна дужина 35 mm (слика)"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "ГПС географска ширина (слика)"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "ГПС географска дужина (слика)"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "ГПС надморска висина (слика)"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ИСО разреди брзине (слика)"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "мерење осветљења (слика)"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "x‑величина (слика)"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "у‑величина (слика)"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "оштрина (слика)"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "уравнотежавање беле (слика)"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "издавач"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "година издања"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "узорковање"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "тема"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "наслов"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "број нумере"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "број диска"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "текстописац"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "ширина"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "број речи"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "преводиве јединице"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "преводи"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "нацрти превода"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "аутор"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "последња измена"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "стварање шаблона"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "преузето са"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "тема прилога е‑поште"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "пошиљалац прилога е‑поште"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ИД поруке прилога е‑поште"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "архива"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "аудио"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "документ"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "слика"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "презентација"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "таблица"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "текст"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "видео"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "фасцикла"

--- a/po/sr@ijekavian/kfilemetadata5.po
+++ b/po/sr@ijekavian/kfilemetadata5.po
@@ -1,0 +1,873 @@
+# Translation of kfilemetadata5.po into Serbian.
+# Chusslove Illich <caslav.ilic@gmx.net>, 2014, 2015, 2016, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata5\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2017-10-30 23:08+0100\n"
+"Last-Translator: Chusslove Illich <caslav.ilic@gmx.net>\n"
+"Language-Team: Serbian <kde-i18n-sr@kde.org>\n"
+"Language: sr@ijekavian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+"X-Environment: kde\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "преводи"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "блиц (слика)"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "албум"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "извођач албума"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "извођач"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "пропорција"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "аутор"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "битски проток"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "канала"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "коментар"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "композитор"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "ауторска права"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "датум стварања"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "број кадрова"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "генератор документа"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "жанр"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "висина"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "датум-време (слика)"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "модел (слика)"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "оријентација (слика)"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "кључне речи"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "језик"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "број редова"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "текстописац"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "број страница"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "вредност бленде (слика)"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "изворни датум-време (слика)"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "отклон експозиције (слика)"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "време експозиције (слика)"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "блиц (слика)"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "број диска"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "фокусна дужина (слика)"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "фокусна дужина 35 mm (слика)"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "ГПС географска ширина (слика)"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "ГПС географска дужина (слика)"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "ГПС надморска висина (слика)"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ИСО разреди брзине (слика)"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "мјерење освјетљења (слика)"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "x‑величина (слика)"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "у‑величина (слика)"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "оштрина (слика)"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "уравнотежавање бијеле (слика)"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "издавач"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "година издања"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "узорковање"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "тема"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "наслов"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "број нумере"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "број диска"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "трајање"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "текстописац"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "ширина"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "број речи"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "преводиве јединице"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "преводи"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "нацрти превода"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "аутор"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "последња измена"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "стварање шаблона"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "преузето са"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "тема прилога е‑поште"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "пошиљалац прилога е‑поште"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ИД поруке прилога е‑поште"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "архива"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "аудио"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "документ"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "слика"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "презентација"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "таблица"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "текст"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "видео"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "фасцикла"

--- a/po/sr@ijekavianlatin/kfilemetadata5.po
+++ b/po/sr@ijekavianlatin/kfilemetadata5.po
@@ -1,0 +1,873 @@
+# Translation of kfilemetadata5.po into Serbian.
+# Chusslove Illich <caslav.ilic@gmx.net>, 2014, 2015, 2016, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata5\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2017-10-30 23:08+0100\n"
+"Last-Translator: Chusslove Illich <caslav.ilic@gmx.net>\n"
+"Language-Team: Serbian <kde-i18n-sr@kde.org>\n"
+"Language: sr@ijekavianlatin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+"X-Environment: kde\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "prevodi"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "blic (slika)"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "izvođač albuma"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "izvođač"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "proporcija"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "bitski protok"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "kanala"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "komentar"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "kompozitor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "autorska prava"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "datum stvaranja"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "broj kadrova"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "generator dokumenta"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "žanr"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "visina"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "datum-vreme (slika)"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "model (slika)"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "orijentacija (slika)"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "ključne reči"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "jezik"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "broj redova"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "tekstopisac"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "broj stranica"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "vrednost blende (slika)"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "izvorni datum-vreme (slika)"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "otklon ekspozicije (slika)"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "vreme ekspozicije (slika)"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "blic (slika)"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "broj diska"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "fokusna dužina (slika)"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "fokusna dužina 35 mm (slika)"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS geografska širina (slika)"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS geografska dužina (slika)"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS nadmorska visina (slika)"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO razredi brzine (slika)"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "mjerenje osvjetljenja (slika)"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "x‑veličina (slika)"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "u‑veličina (slika)"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "oštrina (slika)"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "uravnotežavanje bijele (slika)"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "izdavač"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "godina izdanja"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "uzorkovanje"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "tema"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "naslov"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "broj numere"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "broj diska"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "tekstopisac"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "širina"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "broj reči"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "prevodive jedinice"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "prevodi"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "nacrti prevoda"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "poslednja izmena"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "stvaranje šablona"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "preuzeto sa"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "tema priloga e‑pošte"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "pošiljalac priloga e‑pošte"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID poruke priloga e‑pošte"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "arhiva"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "slika"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "prezentacija"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "tablica"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "fascikla"

--- a/po/sr@latin/kfilemetadata5.po
+++ b/po/sr@latin/kfilemetadata5.po
@@ -1,0 +1,873 @@
+# Translation of kfilemetadata5.po into Serbian.
+# Chusslove Illich <caslav.ilic@gmx.net>, 2014, 2015, 2016, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata5\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2017-10-30 23:08+0100\n"
+"Last-Translator: Chusslove Illich <caslav.ilic@gmx.net>\n"
+"Language-Team: Serbian <kde-i18n-sr@kde.org>\n"
+"Language: sr@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Accelerator-Marker: &\n"
+"X-Text-Markup: kde4\n"
+"X-Environment: kde\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "prevodi"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "blic (slika)"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "izvođač albuma"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "izvođač"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "proporcija"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "autor"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "bitski protok"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "kanala"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "komentar"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "kompozitor"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "autorska prava"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "datum stvaranja"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "broj kadrova"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "generator dokumenta"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "žanr"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "visina"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "datum-vreme (slika)"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "model (slika)"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "orijentacija (slika)"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "ključne reči"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "jezik"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "broj redova"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "tekstopisac"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "broj stranica"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "vrednost blende (slika)"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "izvorni datum-vreme (slika)"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "otklon ekspozicije (slika)"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "vreme ekspozicije (slika)"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "blic (slika)"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "broj diska"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "fokusna dužina (slika)"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "fokusna dužina 35 mm (slika)"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS geografska širina (slika)"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS geografska dužina (slika)"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS nadmorska visina (slika)"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO razredi brzine (slika)"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "merenje osvetljenja (slika)"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "x‑veličina (slika)"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "u‑veličina (slika)"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "oštrina (slika)"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "uravnotežavanje bele (slika)"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "izdavač"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "godina izdanja"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "uzorkovanje"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "tema"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "naslov"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "broj numere"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "broj diska"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "trajanje"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "tekstopisac"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "širina"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "broj reči"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "prevodive jedinice"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "prevodi"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "nacrti prevoda"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "autor"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "poslednja izmena"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "stvaranje šablona"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "preuzeto sa"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "tema priloga e‑pošte"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "pošiljalac priloga e‑pošte"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "ID poruke priloga e‑pošte"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "arhiva"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "audio"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "slika"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "prezentacija"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "tablica"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "tekst"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "fascikla"

--- a/po/sv/kfilemetadata5.po
+++ b/po/sv/kfilemetadata5.po
@@ -1,0 +1,823 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Stefan Asserhäll <stefan.asserhall@bredband.net>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-22 09:11+0100\n"
+"Last-Translator: Stefan Asserhäll <stefan.asserhall@bredband.net>\n"
+"Language-Team: Swedish <kde-i18n-doc@kde.org>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Oförändrad"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Vänd horisontellt"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Roterad 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Vänd vertikalt"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Transponerad"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Roterad 90° moturs"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Tvärställd"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Roterad 270° moturs"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Ingen blixt"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Utlöst"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Utlöst, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Utlöst, återsänt ljus detekterat"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ja, utlöstes inte"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ja, obligatorisk"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ja, obligatorisk, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ja, obligatorisk, återsänt ljus detekterat"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Nej, obligatorisk"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Nej, utlöstes inte, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Nej, automatisk"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ja, automatisk"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ja, automatisk, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ja, automatisk, återsänt ljus detekterat"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Ingen blixtfunktion"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Nej, ingen blixtfunktion"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ja, korrigering av röda ögon"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ja, korrigering av röda ögon, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ja, korrigering av röda ögon, återsänt ljus detekterat"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ja, obligatorisk, korrigering av röda ögon"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Ja, obligatorisk, korrigering av röda ögon, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Ja, obligatorisk, korrigering av röda ögon, återsänt ljus detekterat"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Nej, korrigering av röda ögon"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Nej, automatisk, korrigering av röda ögon"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Ja, automatisk, korrigering av röda ögon"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Ja, automatisk, korrigering av röda ögon, återsänt ljus ej detekterat"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ja, automatisk, korrigering av röda ögon, återsänt ljus detekterat"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Okänd"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 bilder/s"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Album"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albumartist"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Artist"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Proportion"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Upphovsman"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bithastighet"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanaler"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Beskrivning"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Tonsättare"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Copyright"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Skapad datum"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Längd"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Bildfrekvens"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Dokument genererat av"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Genre"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Höjd"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Bildens datum och tid"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Tillverkare"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Modell"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Bildorientering"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Nyckelord"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Språk"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Radantal"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Textförfattare"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Sidantal"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Bländarvärde"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Originaldatum och tid"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Exponeringsavvikelse"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Exponeringstid"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Blixt"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Bländartal"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Fokallängd"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Fokallängd 35 mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS-latitud"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS-longitud"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS-höjd"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO-känslighet"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Mätarläge"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X-dimension"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y-dimension"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Färgmättnad"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Skärpa"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Vitbalans"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Förläggare"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Etikett"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Utgivningsår"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Samplingsfrekvens"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Ämne"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Titel"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Spårnummer"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Skivnummer"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Plats"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Artist"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ensemble"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Arrangör"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Kompilering"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Licens"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Sångtext"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Betyg"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Högsta uppspelningsnivå i album"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Uppspelningsnivå album"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Högsta uppspelningsnivå i spår"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Uppspelningsnivå spår"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Bredd"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Ordantal"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Översättningsbara enheter"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Översättningar"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Översättningsutkast"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Upphovsman"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Senaste uppdatering"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Skapa mall"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Nerladdad från"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Rubrik för e-postbilaga"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Avsändare av e-postbilaga"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Brev-id för e-postbilaga"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arkiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Ljud"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Dokument"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Bild"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Presentation"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Kalkylark"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Text"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Katalog"

--- a/po/tg/kfilemetadata5.po
+++ b/po/tg/kfilemetadata5.po
@@ -1,0 +1,825 @@
+# Copyright (C) YEAR This file is copyright:
+# This file is distributed under the same license as the kfilemetadata package.
+#
+# Victor Ibragimov <victor.ibragimov@gmail.com>, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-08-22 19:19+0500\n"
+"Last-Translator: Victor Ibragimov <victor.ibragimov@gmail.com>\n"
+"Language-Team: English <kde-i18n-doc@kde.org>\n"
+"Language: tg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 19.04.3\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/с"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Тағйирнашуда"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Инъикоси уфуқӣ"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Ба 180° давр задан"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Инъикоси амудӣ"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Инъикос нисбат ба диагонали асосӣ"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Ба 90° давр задан (CCW)"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Инъикос нисбат ба диагонали ғайриасосӣ"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Ба 270° давр задан (CCW)"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Бе дурахш"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Дурахш иҷро шуд"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Дурахш иҷро шуд, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Дурахш иҷро шуд, равшании бозгашт муайян шуд"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Ҳа, дурахш иҷро нашуд"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Ҳа, маҷбуран иҷро шуд"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Ҳа, маҷбуран иҷро шуд, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Ҳа, маҷбуран иҷро шуд, равшании бозгашт муайян шуд"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Не, маҷбуран иҷро шуд"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Не, дурахш иҷро нашуд, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Не, ба таври худкор"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Ҳа, ба таври худкор"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Ҳа, ба таври худкор, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Ҳа, ба таври худкор, равшании бозгашт муайян шуд"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Бе вазифаи дурахш"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Не, бе вазифаи дурахш"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Ҳа, камкунии чашми сурх"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Ҳа, камкунии чашми сурх, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Ҳа, камкунии чашми сурх, равшании бозгашт муайян шуд"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Ҳа, маҷбуран иҷро шуд, камкунии чашми сурх"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Ҳа, маҷбуран иҷро шуд, камкунии чашми сурх, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+"Ҳа, маҷбуран иҷро шуд, камкунии чашми сурх, равшании бозгашт муайян шуд"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Не, камкунии чашми сурх"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Не, ба таври худкор, камкунии чашми сурх"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Ҳа, ба таври худкор, камкунии чашми сурх"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+"Ҳа, ба таври худеор, камкунии чашми сурх, равшании бозгашт муайян нашуд"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Ҳа, ба таври худеор, камкунии чашми сурх, равшании бозгашт муайян шуд"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Номаълум"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 мм"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 кдс"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 с"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 с"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Албом"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Ҳунарманди албом"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Ҳунарманд"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Таносуб"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Муаллиф"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Битрейт"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Шабакаҳо"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Шарҳ"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Тавсиф"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Баcтакop"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Ҳуқуқи муаллиф"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Санаи эҷод"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Давомнокӣ"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Зичии аксҳо"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Ҳуҷҷати эҷодшуда аз ҷониби"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Жанр"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Баландӣ"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Вақт ва санаи тасвир"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Иcтeҳcoлкyнанда"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Намуна"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Самтёбии тасвир"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Калидвожаҳо"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Забон"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Шумораи сатрҳо"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Шеърнавис"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Шумораи саҳифаҳо"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Қимати диафрагма"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Вақт ва санаи аслӣ"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Ислоҳи намоишдиҳӣ"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Вақти намоишдиҳӣ"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Дурахш"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Рақами F"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Дарозии фокус"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Дарозии фокус 35 мм"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Арзи GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Тӯли GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Фарози GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Баҳои суръати ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Реҷаи ченкунӣ"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Андозаи X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Андозаи Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Серобшавӣ"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Тезӣ"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Мувозинати сафед"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Ношир"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Тамға"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Соли барориш"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Зичии намунавӣ"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Мавзӯъ"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Сарлавҳа"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Рақами роҳча"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Рақами диск"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Ҷойгиршавӣ"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Иҷрокунанда"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Гурӯҳ"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Тартибдиҳанда"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Дирижёр"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Ҳамгардонӣ"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Иҷозатнома"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Лирика"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Аcаpи мycиқӣ"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Баҳо"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Коркарди нуқтаи баландии садои албом"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Коркарди баландии садои албом"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Коркарди нуқтаи баландии садои роҳча"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Коркарди баландии садои роҳча"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Паҳнӣ"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Шумораи калимаҳо"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Маводи тарҷумашаванда"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Тарҷумаҳо"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Тарҷумаҳои сиёҳнавис"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Муаллиф"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Навсозии охирин"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Эҷодкунии қолибҳо"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Макори боргирӣ"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Мавзӯи замимаи почтаи электронӣ"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Фиристандаи замимаи почтаи электронӣ"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Рақами мушаххаси паёми замимаи почтаи электронӣ"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Бойгонӣ"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Аудио"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Ҳуҷҷат"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Тасвир"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Тақдим"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Ҷадвали электронӣ"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Матн"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Видео"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Ҷузвадон"

--- a/po/tr/kfilemetadata5.po
+++ b/po/tr/kfilemetadata5.po
@@ -1,0 +1,872 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Volkan Gezer <volkangezer@gmail.com>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2017-10-23 09:49+0000\n"
+"Last-Translator: Kaan <kaanozdincer@gmail.com>\n"
+"Language-Team: Turkish <kde-l10n-tr@kde.org>\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr ""
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr ""
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr ""
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr ""
+
+#: src/formatstrings.cpp:82
+#, fuzzy, kde-format
+#| msgctxt "@label number of translated strings"
+#| msgid "Translations"
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Çeviriler"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr ""
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr ""
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr ""
+
+#: src/formatstrings.cpp:96
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Fotoğraf Flaş"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr ""
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr ""
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr ""
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr ""
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr ""
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr ""
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr ""
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr ""
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr ""
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr ""
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr ""
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr ""
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr ""
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr ""
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr ""
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr ""
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Albüm"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Albüm Sanatçısı"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Sanatçı"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "En Boy Oranı"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Yazar"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Bit hızı"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Kanallar"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Yorum"
+
+#: src/propertyinfo.cpp:100
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Description"
+msgstr "Süre"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Besteci"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Telif hakkı"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Oluşturulma Tarihi"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Süre"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Kare Hızı"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Belgeyi Oluşturan"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Tür"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Yükseklik"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Resim Tarih Zaman"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr ""
+
+#: src/propertyinfo.cpp:179
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Image Model"
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Resim Modeli"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Resim Yönlendirme"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Anahtar Kelimeler"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Dil"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Satır Sayısı"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Söz Yazarı"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Sayfa Sayısı"
+
+#: src/propertyinfo.cpp:225
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Aperture Value"
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Sayfa Açıklığı Değeri"
+
+#: src/propertyinfo.cpp:232
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Original Date Time"
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Fotoğrafın Orijinal Tarih Zamanı"
+
+#: src/propertyinfo.cpp:239
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Bias"
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Resim Pozlama Dengeleme"
+
+#: src/propertyinfo.cpp:246
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Exposure Time"
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Fotoğraf Pozlama Süresi"
+
+#: src/propertyinfo.cpp:253
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Flash"
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Fotoğraf Flaş"
+
+#: src/propertyinfo.cpp:260
+#, fuzzy, kde-format
+#| msgctxt "@label music disc number"
+#| msgid "Disc Number"
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Disk Numarası"
+
+#: src/propertyinfo.cpp:267
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length"
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Fotoğraf Odak uzunluğu"
+
+#: src/propertyinfo.cpp:274
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Focal Length 35mm"
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Fotoğraf Odak Uzunluğu 35mm"
+
+#: src/propertyinfo.cpp:281
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Latitude"
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Fotoğraf GPS Enlemi"
+
+#: src/propertyinfo.cpp:288
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Longitude"
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Fotoğraf GPS Boylamı"
+
+#: src/propertyinfo.cpp:295
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo GPS Altitude"
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Fotoğraf GPS Rakımı"
+
+#: src/propertyinfo.cpp:302
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo ISO Speed Rating"
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Fotoğraf ISO Hız Değerlendirmesi"
+
+#: src/propertyinfo.cpp:308
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Metering Mode"
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Fotoğraf Ölçüm Kipi"
+
+#: src/propertyinfo.cpp:314
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo X Dimension"
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Fotoğraf X Boyutu"
+
+#: src/propertyinfo.cpp:320
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Y Dimension"
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Fotoğraf Y Boyutu"
+
+#: src/propertyinfo.cpp:326
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Süre"
+
+#: src/propertyinfo.cpp:332
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo Sharpness"
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Fotoğraf Keskinliği"
+
+#: src/propertyinfo.cpp:338
+#, fuzzy, kde-format
+#| msgctxt "@label EXIF"
+#| msgid "Photo White Balance"
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Fotoğraf Beyaz Dengesi"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Yayıncı"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr ""
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Yayınlanma Yılı"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Örnek Oranı"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Konu"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Başlık"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Parça Numarası"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Disk Numarası"
+
+#: src/propertyinfo.cpp:394
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Duration"
+msgctxt "@label"
+msgid "Location"
+msgstr "Süre"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr ""
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr ""
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr ""
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr ""
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr ""
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr ""
+
+#: src/propertyinfo.cpp:436
+#, fuzzy, kde-format
+#| msgctxt "@label"
+#| msgid "Lyricist"
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Söz Yazarı"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr ""
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr ""
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr ""
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr ""
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Genişlik"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Kelime Sayımı"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Çevrilebilir Birimler"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Çeviriler"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Taslak Çeviriler"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Yazar"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Son Güncelleme"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Şablon Oluşturmak"
+
+#: src/propertyinfo.cpp:540
+#, fuzzy, kde-format
+#| msgctxt "@label the URL a file was originally downloded from"
+#| msgid "Downloaded From"
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "İndirme Adresi"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "E-Posta Eklenti Konusu"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "E-Posta Eklenti Göndereni"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "E-Posta Eklenti İleti ID'si"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Arşiv"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Ses"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Belge"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Resim"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Tanıtım"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Tablo"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Metin"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Video"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Klasör"

--- a/po/uk/kfilemetadata5.po
+++ b/po/uk/kfilemetadata5.po
@@ -1,0 +1,826 @@
+# Translation of kfilemetadata5.po to Ukrainian
+# Copyright (C) 2018-2019 This_file_is_part_of_KDE
+# This file is distributed under the license LGPL version 2.1 or
+# version 3 or later versions approved by the membership of KDE e.V.
+#
+# Yuri Chornoivan <yurchor@ukr.net>, 2014, 2015, 2016, 2017, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: kfilemetadata5\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-22 08:00+0300\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Lokalize 19.07.70\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/с"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "Без змін"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "Перевернути горизонтально"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "Повернути на 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "Перевернути вертикально"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "Обернути навколо діагоналі"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "Обернуте на 90° проти год. стрілки"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "Обернути навколо бічної діагоналі"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "Обернуте на 270° проти год. стрілки"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "Без спалаху"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "Використано"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "Спрацював, не виявлено відбите світло"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "Спрацював, виявлено відбите світло"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "Так, не спрацював"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "Так, примусовий"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "Так, примусовий, не виявлено відбите світло"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "Так, примусовий, виявлено відбите світло"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "Ні, примусовий"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "Ні, не спрацював, не виявлено відбите світло"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "Ні, автоматично"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "Так, автоматично"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "Так, авто, не виявлено відбите світло"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "Так, авто, виявлено відбите світло"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "Без функції спалаху"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "Ні, без функції спалаху"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "Так, придушення ефекту «червоних очей»"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "Так, придушення «червоних очей», не виявлено відбите світло"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "Так, придушення «червоних очей», виявлено відбите світло"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "Так, примусовий, придушення «червоних очей»"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr ""
+"Так, примусовий, придушення «червоних очей», не виявлено відбите світло"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "Так, примусовий, придушення «червоних очей», виявлено відбите світло"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "Ні, придушення ефекту «червоних очей»"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "Ні, авто, зменшення червоності очей"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "Так, авто, зменшення червоності очей"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "Так, авто, придушення «червоних очей», не виявлено відбите світло"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "Так, авто, придушення «червоних очей», виявлено відбите світло"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "Невідомо"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 мм"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 кд/с"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 с"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 с"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "Альбом"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "Виконавець альбому"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "Виконавець"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "Співвідношення розмірів"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "Автор"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "Бітова швидкість"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "Канали"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "Коментар"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "Опис"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "Композитор"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "Авторські права"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "Дата створення"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "Тривалість"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "Частота кадрів"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "Документ створено за допомогою"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "Жанр"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "Висота"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "Дата і час зйомки"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "Виробник"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "Модель"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "Орієнтація зображення"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "Ключові слова"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "Мова"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "Кількість рядків"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "Автор тексту"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "Кількість сторінок"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "Розмір діафрагми"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "Дата і час створення оригіналу"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "Ухил експозиції"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "Час експонування"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "Фотоспалах"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "Діафрагмове число"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "Фокусна відстань"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "Фокусна відстань 35 мм"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "Широта за GPS"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "Довгота за GPS"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "Висота за GPS"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "Рейтинг швидкості ISO"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "Режим вимірювання"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "Розмірність за X"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Розмірність за Y"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "Насиченість"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "Різкість"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "Баланс білого"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "Видавець"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "Лейбл"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "Рік випуску"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "Частота дискретизації"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "Тема"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "Заголовок"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "Номер композиції"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "Номер диска"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "Місце"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "Виконавець"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "Ансамбль"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "Аранжувальник"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "Диригент"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "Компіляція"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "Ліцензування"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "Текст пісні"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Опус"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "Оцінка"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "Пікова гучність альбому при вирівнюванні гучності"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "Збільшення гучності альбому при вирівнюванні гучності"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "Пікова гучність композиції при вирівнюванні гучності"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "Збільшення гучності композиції при вирівнюванні гучності"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "Ширина"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "Кількість слів"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "Придатні до перекладу модулі"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "Переклади"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "Чернетки перекладів"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "Автор"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "Останнє оновлення"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "Час створення шаблона"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "Отримано з"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "Тема долучення електронної пошти"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "Відправник долучення електронної пошти"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "Ідентифікатор повідомлення долучення електронної пошти"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "Архів"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "Звук"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "Документ"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "Зображення"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "Презентація"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "Електронні таблиці"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "Текст"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "Відео"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "Тека"

--- a/po/zh_CN/kfilemetadata5.po
+++ b/po/zh_CN/kfilemetadata5.po
@@ -1,0 +1,829 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Feng Chao <chaofeng111@gmail.com>, 2014.
+# Lie Ex <lilith.ex@gmail.com>, 2014.
+# Xuetian Weng <xweng@cs.stonybrook.edu>, 2014.
+# Weng Xuetian <wengxt@gmail.com>, 2014, 2015, 2016, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: kdeorg\n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2021-04-24 15:42\n"
+"Last-Translator: \n"
+"Language-Team: Chinese Simplified\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Crowdin-Project: kdeorg\n"
+"X-Crowdin-Project-ID: 269464\n"
+"X-Crowdin-Language: zh-CN\n"
+"X-Crowdin-File: /kf5-trunk/messages/kfilemetadata/kfilemetadata5.pot\n"
+"X-Crowdin-File-ID: 5564\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/s"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "不改变"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "水平翻转"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "旋转 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "竖直翻转"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "移位"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "逆时针旋转 90° "
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "横断"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "逆时针旋转 270°"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "无闪光灯"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "已激发"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "已激发，未检测到返回光"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "已激发，检测到返回光"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "是，未激发"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "是，强制"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "是，强制，未检测到返回光"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "是，强制，检测到返回光"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "否，强制"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "否，未激发，未检测到返回光"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "否，自动"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "是，自动"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "是，自动，未检测到返回光"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "是，自动，检测到返回光"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "无闪光灯功能"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "否，无闪光灯功能"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "是，消除红眼"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "是，消除红眼，未检测到返回光"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "是，消除红眼，检测到返回光"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "是，强制，消除红眼"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "是，强制，消除红眼，未检测到返回光"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "是，强制，消除红眼，检测到返回光"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "否，消除红眼"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "否，自动，消除红眼"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "是，自动，消除红眼"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "是，自动，消除红眼，未检测到返回光"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "是，自动，消除红眼，检测到返回光"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "未知"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 mm"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 fps"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 s"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 s"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "专辑"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "专辑艺人"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "艺人"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "纵横比"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "作者"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "比特率"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "声道"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "评论"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "描述"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "作曲家"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "版权"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "创建日期"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "时长"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "帧速率"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "文档生成自"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "流派"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "高度"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "图像日期和时间"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "制造商"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "型号"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "图像方向"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "关键字"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "语言"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "行数"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "作词"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "页数"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "光圈值"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "原始日期时间"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "曝光偏差"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "曝光时间"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "闪光灯"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "F 数"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "焦距"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "焦距 35mm"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS 纬度"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS 经度"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS 海拔"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO 速率"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "测距模式"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X 尺寸"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y 尺寸"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "饱和度"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "锐度"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "白平衡"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "出版"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "标签"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "发行年份"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "采样率"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "主题"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "标题"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "曲目编号"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "盘片编号"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "位置"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "演绎者"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "集成"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "编曲"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "指挥"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "编译"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "许可证"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "歌词"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "Opus"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "评分"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "回放增益专辑峰值"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "回放增益专辑增益"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "回放增益曲目峰值"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "回放增益曲目增益"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "宽度"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "单词计数"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "翻译单元"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "翻译"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "翻译草稿"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "作者"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "上次更新"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "模板创建"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "下载来源"
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "电子邮件附件主题"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "电子邮件附件发信人"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "电子邮件附件消息 ID"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "存档"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "音频"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "文档"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "图像"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "演示"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "电子表格"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "文本"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "视频"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "文件夹"

--- a/po/zh_TW/kfilemetadata5.po
+++ b/po/zh_TW/kfilemetadata5.po
@@ -1,0 +1,824 @@
+# Copyright (C) YEAR This_file_is_part_of_KDE
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Franklin Weng <franklin at goodhorse dot idv dot tw>, 2014, 2015, 2017.
+# Jeff Huang <s8321414@gmail.com>, 2016, 2017, 2018.
+# pan93412 <pan93412@gmail.com>, 2018, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://bugs.kde.org\n"
+"POT-Creation-Date: 2020-06-09 02:02+0200\n"
+"PO-Revision-Date: 2019-06-25 13:49+0800\n"
+"Last-Translator: pan93412 <pan93412@gmail.com>\n"
+"Language-Team: Chinese <zh-l10n@lists.linux.org.tw>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Lokalize 19.04.2\n"
+
+#: src/formatstrings.cpp:64
+#, kde-format
+msgctxt "@label bitrate (per second)"
+msgid "%1/s"
+msgstr "%1/秒"
+
+#: src/formatstrings.cpp:78
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Unchanged"
+msgstr "未變更"
+
+#: src/formatstrings.cpp:79
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Horizontally flipped"
+msgstr "水平翻轉"
+
+#: src/formatstrings.cpp:80
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "180° rotated"
+msgstr "旋轉 180°"
+
+#: src/formatstrings.cpp:81
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Vertically flipped"
+msgstr "垂直翻轉"
+
+#: src/formatstrings.cpp:82
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transposed"
+msgstr "轉置"
+
+#: src/formatstrings.cpp:83
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "90° rotated CCW "
+msgstr "逆時針旋轉 90°"
+
+#: src/formatstrings.cpp:84
+#, kde-format
+msgctxt "Description of image orientation"
+msgid "Transversed"
+msgstr "橫穿"
+
+#: src/formatstrings.cpp:85
+#, kde-format
+msgctxt "Description of image orientation, counter clock-wise rotated"
+msgid "270° rotated CCW"
+msgstr "逆時針旋轉 270°"
+
+#: src/formatstrings.cpp:96
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash"
+msgstr "沒有閃光燈"
+
+#: src/formatstrings.cpp:97
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired"
+msgstr "有開閃光燈"
+
+#: src/formatstrings.cpp:98
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light not detected"
+msgstr "有開閃光燈，且沒偵測到回光"
+
+#: src/formatstrings.cpp:99
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Fired, return light detected"
+msgstr "有開閃光燈，且有偵測到回光"
+
+#: src/formatstrings.cpp:100
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, did not fire"
+msgstr "是，未開閃光燈"
+
+#: src/formatstrings.cpp:101
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory"
+msgstr "是，強制要求"
+
+#: src/formatstrings.cpp:102
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light not detected"
+msgstr "是，強制要求，未偵測到回光"
+
+#: src/formatstrings.cpp:103
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, return light detected"
+msgstr "是，強制要求，有偵測到回光"
+
+#: src/formatstrings.cpp:104
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, compulsory"
+msgstr "否，強制要求"
+
+#: src/formatstrings.cpp:105
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, did not fire, return light not detected"
+msgstr "否，未開閃光燈，未偵測到回光"
+
+#: src/formatstrings.cpp:106
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto"
+msgstr "否，自動調整"
+
+#: src/formatstrings.cpp:107
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto"
+msgstr "是，自動調整"
+
+#: src/formatstrings.cpp:108
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light not detected"
+msgstr "是，自動調整，未偵測到回光"
+
+#: src/formatstrings.cpp:109
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, return light detected"
+msgstr "是，自動調整，有偵測到回光"
+
+#: src/formatstrings.cpp:110
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No flash function"
+msgstr "無閃光燈功能"
+
+#: src/formatstrings.cpp:111
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, no flash function"
+msgstr "否，無閃光燈功能"
+
+#: src/formatstrings.cpp:112
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction"
+msgstr "是，有開消除紅眼功能"
+
+#: src/formatstrings.cpp:113
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light not detected"
+msgstr "是，有開消除紅眼功能，未偵測到回光"
+
+#: src/formatstrings.cpp:114
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, red-eye reduction, return light detected"
+msgstr "是，有開消除紅眼功能，有偵測到回光"
+
+#: src/formatstrings.cpp:115
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction"
+msgstr "是，強制要求，有開消除紅眼功能"
+
+#: src/formatstrings.cpp:116
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light not detected"
+msgstr "是，強制要求，有開消除紅眼功能，未偵測到回光"
+
+#: src/formatstrings.cpp:117
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, compulsory, red-eye reduction, return light detected"
+msgstr "是，強制要求，有開消除紅眼功能，有偵測到回光"
+
+#: src/formatstrings.cpp:118
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, red-eye reduction"
+msgstr "否，有開消除紅眼功能"
+
+#: src/formatstrings.cpp:119
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "No, auto, red-eye reduction"
+msgstr "否，自動調整，有開消除紅眼功能"
+
+#: src/formatstrings.cpp:120
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction"
+msgstr "是，自動調整，有開消除紅眼功能"
+
+#: src/formatstrings.cpp:121
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light not detected"
+msgstr "是，自動調整，有開消除紅眼功能，未偵測到回光"
+
+#: src/formatstrings.cpp:122
+#, kde-format
+msgctxt "Description of photo flash"
+msgid "Yes, auto, red-eye reduction, return light detected"
+msgstr "是，自動調整，有開消除紅眼功能，有偵測到回光"
+
+#: src/formatstrings.cpp:127
+#, kde-format
+msgid "Unknown"
+msgstr "未知"
+
+#: src/formatstrings.cpp:134
+#, kde-format
+msgctxt "Symbol of degree, no space"
+msgid "%1°"
+msgstr "%1°"
+
+#: src/formatstrings.cpp:145
+#, kde-format
+msgctxt "Focal length given in mm"
+msgid "%1 mm"
+msgstr "%1 毫米"
+
+#: src/formatstrings.cpp:150
+#, kde-format
+msgctxt "Symbol of frames per second, with space"
+msgid "%1 fps"
+msgstr "%1 FPS"
+
+#: src/formatstrings.cpp:160
+#, kde-format
+msgctxt "Time period given in seconds as rational number, denominator is given"
+msgid "1/%1 s"
+msgstr "1/%1 秒"
+
+#: src/formatstrings.cpp:163
+#, kde-format
+msgctxt "Time period given in seconds"
+msgid "%1 s"
+msgstr "%1 秒"
+
+#: src/formatstrings.cpp:179
+#, kde-format
+msgctxt "Exposure bias/compensation in exposure value (EV)"
+msgid "%1 EV"
+msgstr "%1 EV"
+
+#: src/formatstrings.cpp:193
+#, kde-format
+msgctxt ""
+"Exposure compensation given as integral with fraction, in exposure value (EV)"
+msgid "%1 %2/%3 EV"
+msgstr "%1 %2/%3 EV"
+
+#: src/formatstrings.cpp:196
+#, kde-format
+msgctxt "Exposure compensation given as rational, in exposure value (EV)"
+msgid "%1/%2 EV"
+msgstr "%1/%2 EV"
+
+#: src/formatstrings.cpp:201
+#, kde-format
+msgctxt "Aspect ratio, normalized to one"
+msgid "%1:1"
+msgstr "%1:1"
+
+#: src/formatstrings.cpp:206
+#, kde-format
+msgctxt "F number for photographs"
+msgid "f/%1"
+msgstr "f/%1"
+
+#: src/propertyinfo.cpp:49
+#, kde-format
+msgctxt "@label music album"
+msgid "Album"
+msgstr "專輯"
+
+#: src/propertyinfo.cpp:55
+#, kde-format
+msgctxt "@label"
+msgid "Album Artist"
+msgstr "專輯的演出者"
+
+#: src/propertyinfo.cpp:61
+#, kde-format
+msgctxt "@label"
+msgid "Artist"
+msgstr "演出者"
+
+#: src/propertyinfo.cpp:67
+#, kde-format
+msgctxt "@label"
+msgid "Aspect Ratio"
+msgstr "外觀比例"
+
+#: src/propertyinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Author"
+msgstr "作者"
+
+#: src/propertyinfo.cpp:80
+#, kde-format
+msgctxt "@label"
+msgid "Bitrate"
+msgstr "位元率"
+
+#: src/propertyinfo.cpp:87
+#, kde-format
+msgctxt "@label"
+msgid "Channels"
+msgstr "聲道"
+
+#: src/propertyinfo.cpp:93
+#, kde-format
+msgctxt "@label"
+msgid "Comment"
+msgstr "註解"
+
+#: src/propertyinfo.cpp:100
+#, kde-format
+msgctxt "@label"
+msgid "Description"
+msgstr "描述"
+
+#: src/propertyinfo.cpp:107
+#, kde-format
+msgctxt "@label"
+msgid "Composer"
+msgstr "作曲家"
+
+#: src/propertyinfo.cpp:113
+#, kde-format
+msgctxt "@label"
+msgid "Copyright"
+msgstr "版權"
+
+#: src/propertyinfo.cpp:120
+#, kde-format
+msgctxt "@label"
+msgid "Creation Date"
+msgstr "建立日期"
+
+#: src/propertyinfo.cpp:127
+#, kde-format
+msgctxt "@label"
+msgid "Duration"
+msgstr "期間"
+
+#: src/propertyinfo.cpp:139
+#, kde-format
+msgctxt "@label"
+msgid "Frame Rate"
+msgstr "影格率"
+
+#: src/propertyinfo.cpp:146
+#, kde-format
+msgctxt "@label"
+msgid "Document Generated By"
+msgstr "文件產生於"
+
+#: src/propertyinfo.cpp:153
+#, kde-format
+msgctxt "@label music genre"
+msgid "Genre"
+msgstr "風格"
+
+#: src/propertyinfo.cpp:159
+#, kde-format
+msgctxt "@label"
+msgid "Height"
+msgstr "高度"
+
+#: src/propertyinfo.cpp:165
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Date Time"
+msgstr "影像日期時間"
+
+#: src/propertyinfo.cpp:172
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Manufacturer"
+msgstr "製造商"
+
+#: src/propertyinfo.cpp:179
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Model"
+msgstr "型號"
+
+#: src/propertyinfo.cpp:186
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Image Orientation"
+msgstr "影像方向"
+
+#: src/propertyinfo.cpp:193
+#, kde-format
+msgctxt "@label"
+msgid "Keywords"
+msgstr "關鍵字"
+
+#: src/propertyinfo.cpp:200
+#, kde-format
+msgctxt "@label"
+msgid "Language"
+msgstr "語言"
+
+#: src/propertyinfo.cpp:207
+#, kde-format
+msgctxt "@label number of lines"
+msgid "Line Count"
+msgstr "行數"
+
+#: src/propertyinfo.cpp:213
+#, kde-format
+msgctxt "@label"
+msgid "Lyricist"
+msgstr "作詞者"
+
+#: src/propertyinfo.cpp:219
+#, kde-format
+msgctxt "@label"
+msgid "Page Count"
+msgstr "頁面計數"
+
+#: src/propertyinfo.cpp:225
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Aperture Value"
+msgstr "光圈值"
+
+#: src/propertyinfo.cpp:232
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Original Date Time"
+msgstr "原始日期時間"
+
+#: src/propertyinfo.cpp:239
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Bias"
+msgstr "曝光偏移"
+
+#: src/propertyinfo.cpp:246
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Exposure Time"
+msgstr "曝光時間"
+
+#: src/propertyinfo.cpp:253
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Flash"
+msgstr "閃光燈"
+
+#: src/propertyinfo.cpp:260
+#, kde-format
+msgctxt "@label EXIF"
+msgid "F Number"
+msgstr "光圈值"
+
+#: src/propertyinfo.cpp:267
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length"
+msgstr "焦距"
+
+#: src/propertyinfo.cpp:274
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Focal Length 35mm"
+msgstr "35mm 焦距"
+
+#: src/propertyinfo.cpp:281
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Latitude"
+msgstr "GPS 緯度"
+
+#: src/propertyinfo.cpp:288
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Longitude"
+msgstr "GPS 經度"
+
+#: src/propertyinfo.cpp:295
+#, kde-format
+msgctxt "@label EXIF"
+msgid "GPS Altitude"
+msgstr "GPS 高度"
+
+#: src/propertyinfo.cpp:302
+#, kde-format
+msgctxt "@label EXIF"
+msgid "ISO Speed Rating"
+msgstr "ISO 速度評比"
+
+#: src/propertyinfo.cpp:308
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Metering Mode"
+msgstr "測光模式"
+
+#: src/propertyinfo.cpp:314
+#, kde-format
+msgctxt "@label EXIF"
+msgid "X Dimension"
+msgstr "X 軸"
+
+#: src/propertyinfo.cpp:320
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Y Dimension"
+msgstr "Y 軸"
+
+#: src/propertyinfo.cpp:326
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Saturation"
+msgstr "飽和度"
+
+#: src/propertyinfo.cpp:332
+#, kde-format
+msgctxt "@label EXIF"
+msgid "Sharpness"
+msgstr "銳利度"
+
+#: src/propertyinfo.cpp:338
+#, kde-format
+msgctxt "@label EXIF"
+msgid "White Balance"
+msgstr "白平衡"
+
+#: src/propertyinfo.cpp:344
+#, kde-format
+msgctxt "@label"
+msgid "Publisher"
+msgstr "發行者"
+
+#: src/propertyinfo.cpp:350
+#, kde-format
+msgctxt "@label"
+msgid "Label"
+msgstr "標籤"
+
+#: src/propertyinfo.cpp:356
+#, kde-format
+msgctxt "@label"
+msgid "Release Year"
+msgstr "發行年份"
+
+#: src/propertyinfo.cpp:362
+#, kde-format
+msgctxt "@label"
+msgid "Sample Rate"
+msgstr "取樣頻率"
+
+#: src/propertyinfo.cpp:369
+#, kde-format
+msgctxt "@label"
+msgid "Subject"
+msgstr "主題"
+
+#: src/propertyinfo.cpp:376
+#, kde-format
+msgctxt "@label"
+msgid "Title"
+msgstr "標題"
+
+#: src/propertyinfo.cpp:382
+#, kde-format
+msgctxt "@label music track number"
+msgid "Track Number"
+msgstr "曲目編號"
+
+#: src/propertyinfo.cpp:388
+#, kde-format
+msgctxt "@label music disc number"
+msgid "Disc Number"
+msgstr "碟片編號"
+
+#: src/propertyinfo.cpp:394
+#, kde-format
+msgctxt "@label"
+msgid "Location"
+msgstr "位置"
+
+#: src/propertyinfo.cpp:400
+#, kde-format
+msgctxt "@label"
+msgid "Performer"
+msgstr "演員"
+
+#: src/propertyinfo.cpp:406
+#, kde-format
+msgctxt "@label"
+msgid "Ensemble"
+msgstr "合奏"
+
+#: src/propertyinfo.cpp:412
+#, kde-format
+msgctxt "@label"
+msgid "Arranger"
+msgstr "編曲者"
+
+#: src/propertyinfo.cpp:418
+#, kde-format
+msgctxt "@label"
+msgid "Conductor"
+msgstr "指揮者"
+
+#: src/propertyinfo.cpp:424
+#, kde-format
+msgctxt "@label"
+msgid "Compilation"
+msgstr "彙集"
+
+#: src/propertyinfo.cpp:430
+#, kde-format
+msgctxt "@label"
+msgid "License"
+msgstr "版權"
+
+#: src/propertyinfo.cpp:436
+#, kde-format
+msgctxt "@label"
+msgid "Lyrics"
+msgstr "歌詞"
+
+#: src/propertyinfo.cpp:442
+#, kde-format
+msgctxt "@label"
+msgid "Opus"
+msgstr "作品"
+
+#: src/propertyinfo.cpp:448
+#, kde-format
+msgctxt "@label"
+msgid "Rating"
+msgstr "評分"
+
+#: src/propertyinfo.cpp:454
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Peak"
+msgstr "重播增益專輯峰值"
+
+#: src/propertyinfo.cpp:461
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Album Gain"
+msgstr "重播增益專輯增益"
+
+#: src/propertyinfo.cpp:468
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Peak"
+msgstr "重播增益音軌峰值"
+
+#: src/propertyinfo.cpp:475
+#, kde-format
+msgctxt "@label"
+msgid "Replay Gain Track Gain"
+msgstr "重播增益音軌增益"
+
+#: src/propertyinfo.cpp:482
+#, kde-format
+msgctxt "@label"
+msgid "Width"
+msgstr "寬度"
+
+#: src/propertyinfo.cpp:488
+#, kde-format
+msgctxt "@label number of words"
+msgid "Word Count"
+msgstr "字數"
+
+#: src/propertyinfo.cpp:495
+#, kde-format
+msgctxt "@label number of translatable strings"
+msgid "Translatable Units"
+msgstr "可翻譯單元"
+
+#: src/propertyinfo.cpp:502
+#, kde-format
+msgctxt "@label number of translated strings"
+msgid "Translations"
+msgstr "翻譯"
+
+#: src/propertyinfo.cpp:510
+#, kde-format
+msgctxt "@label number of fuzzy translated strings"
+msgid "Draft Translations"
+msgstr "草稿翻譯"
+
+#: src/propertyinfo.cpp:517
+#, kde-format
+msgctxt "@label translation author"
+msgid "Author"
+msgstr "作者"
+
+#: src/propertyinfo.cpp:524
+#, kde-format
+msgctxt "@label translations last update"
+msgid "Last Update"
+msgstr "上次更新"
+
+#: src/propertyinfo.cpp:532
+#, kde-format
+msgctxt "@label date of template creation8"
+msgid "Template Creation"
+msgstr "樣本建立"
+
+#: src/propertyinfo.cpp:540
+#, kde-format
+msgctxt "@label the URL a file was originally downloaded from"
+msgid "Downloaded From"
+msgstr "下載來源："
+
+#: src/propertyinfo.cpp:547
+#, kde-format
+msgctxt "@label the subject of an email this file was attached to"
+msgid "E-Mail Attachment Subject"
+msgstr "電子郵件附件主旨"
+
+#: src/propertyinfo.cpp:554
+#, kde-format
+msgctxt "@label the sender of an email this file was attached to"
+msgid "E-Mail Attachment Sender"
+msgstr "電子郵件附件傳送者"
+
+#: src/propertyinfo.cpp:561
+#, kde-format
+msgctxt "@label the message ID of an email this file was attached to"
+msgid "E-Mail Attachment Message ID"
+msgstr "電子郵件附件訊息 ID"
+
+#: src/typeinfo.cpp:34
+#, kde-format
+msgctxt "@label"
+msgid "Archive"
+msgstr "歸檔"
+
+#: src/typeinfo.cpp:39
+#, kde-format
+msgctxt "@label"
+msgid "Audio"
+msgstr "音效"
+
+#: src/typeinfo.cpp:44
+#, kde-format
+msgctxt "@label"
+msgid "Document"
+msgstr "文件"
+
+#: src/typeinfo.cpp:49
+#, kde-format
+msgctxt "@label"
+msgid "Image"
+msgstr "影像"
+
+#: src/typeinfo.cpp:54
+#, kde-format
+msgctxt "@label"
+msgid "Presentation"
+msgstr "簡報"
+
+#: src/typeinfo.cpp:59
+#, kde-format
+msgctxt "@label"
+msgid "Spreadsheet"
+msgstr "工作表"
+
+#: src/typeinfo.cpp:64
+#, kde-format
+msgctxt "@label"
+msgid "Text"
+msgstr "文字"
+
+#: src/typeinfo.cpp:69
+#, kde-format
+msgctxt "@label"
+msgid "Video"
+msgstr "影片"
+
+#: src/typeinfo.cpp:74
+#, kde-format
+msgctxt "@label"
+msgid "Folder"
+msgstr "資料夾"

--- a/src/extractorcollection.cpp
+++ b/src/extractorcollection.cpp
@@ -111,7 +111,8 @@ void ExtractorCollection::Private::findExtractors()
     // For external plugins, we look into the directories
     const QStringList externalPluginEntryList = externalPluginDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
     for (const QString& externalPlugin : externalPluginEntryList) {
-        if (!QLibrary::isLibrary(externalPlugin)) {
+        if (QLibrary::isLibrary(externalPlugin)) {
+            qCDebug(KFILEMETADATA_LOG) << "Skipping library" << externalPlugin;
             continue;
         }
         if (externalPlugins.contains(externalPlugin)) {


### PR DESCRIPTION
Currently the extractorcollection rejects all files that are not libraries. This is incorrect as we need to allow for executable files in the subdirectories under the designated directory. With the change in this commit the dump utility was able to show the properties for my custom filetype and dolphin shows the properties on the file's details page.
